### PR TITLE
Check all option combinations in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: "50 7 * * *"
   workflow_dispatch:
+    inputs:
+      all_combinations:
+        description: 'Checks all combinations of options'
+        required: true
+        type: boolean
 
 env:
   CARGO_TERM_COLOR: always
@@ -55,11 +60,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Generate and check project
-        if: github.event_name != 'schedule' &&  github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'schedule' &&  !inputs.all_combinations
         run: cd xtask && cargo run -- check ${{ matrix.chip }}
 
       - name: Generate and check project (all combinations)
-        if: github.event_name == 'schedule' ||  github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'schedule' ||  inputs.all_combinations
         run: cd xtask && cargo run -- check ${{ matrix.chip }} --all-combinations
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     paths-ignore:
       - "**/README.md"
+  schedule:
+    - cron: "50 7 * * *"
   workflow_dispatch:
 
 env:
@@ -53,7 +55,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Generate and check project
-        run: cd xtask && cargo run -- check ${{ matrix.chip }} --all
+        if: github.event_name != 'schedule' &&  github.event_name != 'workflow_dispatch'
+        run: cd xtask && cargo run -- check ${{ matrix.chip }}
+
+      - name: Generate and check project (all combinations)
+        if: github.event_name == 'schedule' ||  github.event_name == 'workflow_dispatch'
+        run: cd xtask && cargo run -- check ${{ matrix.chip }} --all-combinations
+
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Generate and check project
-        run: cd xtask && cargo run -- check ${{ matrix.chip }}
+        run: cd xtask && cargo run -- check ${{ matrix.chip }} --all
 
   test:
     runs-on: ubuntu-latest

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -67,7 +67,7 @@ fn check(workspace: &Path, chip: Chip, all_combinations: bool) -> Result<()> {
 
         // Ensure that the generated project builds without errors:
         Command::new("cargo")
-            .args(["build", "--release"])
+            .args(["check", "--release"])
             .current_dir(project_path.join(PROJECT_NAME))
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -54,7 +54,8 @@ fn check(workspace: &Path, chip: Chip, all: bool) -> Result<()> {
 
         // We will generate the project in a temporary directory, to avoid
         // making a mess when this subcommand is executed locally:
-        let project_path = tempfile::tempdir()?.into_path();
+        let project_dir = tempfile::tempdir()?;
+        let project_path = project_dir.path();
         log::info!("PROJECT PATH: {project_path:?}");
 
         // Generate a project targeting the specified chip and using the
@@ -84,6 +85,8 @@ fn check(workspace: &Path, chip: Chip, all: bool) -> Result<()> {
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .output()?;
+
+        project_dir.close()?;
     }
 
     Ok(())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,7 +23,7 @@ enum Commands {
         chip: Chip,
         /// Verify all possible options combinations
         #[arg(short, long)]
-        all: bool,
+        all_combinations: bool,
     },
 }
 
@@ -38,18 +38,21 @@ fn main() -> Result<()> {
     let workspace = workspace.parent().unwrap().canonicalize()?;
 
     match Cli::parse().command {
-        Commands::Check { chip, all } => check(&workspace, chip, all),
+        Commands::Check {
+            chip,
+            all_combinations,
+        } => check(&workspace, chip, all_combinations),
     }
 }
 
 // ----------------------------------------------------------------------------
 // CHECK
 
-fn check(workspace: &Path, chip: Chip, all: bool) -> Result<()> {
+fn check(workspace: &Path, chip: Chip, all_combinations: bool) -> Result<()> {
     log::info!("CHECK: {chip}");
 
     const PROJECT_NAME: &str = "test";
-    for options in options_for_chip(chip, all) {
+    for options in options_for_chip(chip, all_combinations) {
         log::info!("WITH OPTIONS: {options:?}");
 
         // We will generate the project in a temporary directory, to avoid
@@ -92,7 +95,7 @@ fn check(workspace: &Path, chip: Chip, all: bool) -> Result<()> {
     Ok(())
 }
 
-fn options_for_chip(chip: Chip, all: bool) -> Vec<Vec<String>> {
+fn options_for_chip(chip: Chip, all_combinations: bool) -> Vec<Vec<String>> {
     let default_options: Vec<Vec<String>> = vec![
         vec![], // No options
         vec!["alloc".into()],
@@ -115,7 +118,7 @@ fn options_for_chip(chip: Chip, all: bool) -> Vec<Vec<String>> {
             .collect::<Vec<_>>(),
         _ => default_options,
     };
-    if !all {
+    if !all_combinations {
         return available_options;
     } else {
         // Return all the combination of availble options


### PR DESCRIPTION
- Adds a `--all-combinations` flag to the `check` command
- Modified the workflow to use that flag when running scheduled, and when running it manually we should be able to select if we want the flag or not
  - I couldnt test this, yet

CI test run: https://github.com/SergioGasquez/esp-generate/actions/runs/11570938398