### PR TITLE
Editor select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added editor selection. Currently only helix and vscode
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ cargo install esp-generate
   - `wokwi`: Adds support for Wokwi simulation using [VS Code Wokwi extension].
   - `dev-container`: Adds support for [VS Code Dev Containers] and [GitHub Codespaces].
   - `ci` Adds GitHub Actions support with some basics checks.
+- `editors`: Select the editors that will be used with Rust-Analyzer:
+   - `helix`: The Helix Editor
+   - `vscode`: Visual Studio Code
 
 [VS Code Wokwi extension]: https://marketplace.visualstudio.com/items?itemName=wokwi.wokwi-vscode
 [VS Code Dev Containers]: https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,6 +162,26 @@ static OPTIONS: &[GeneratorOptionItem] = &[
             }),
         ],
     }),
+    GeneratorOptionItem::Category(GeneratorOptionCategory {
+        name: "editor",
+        display_name: "Optional editor config files for rust-analyzer",
+        options: &[
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "helix",
+                display_name: "Rust-Analyzer settings for Helix Editor",
+                enables: &[],
+                disables: &[],
+                chips: &[],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "vscode",
+                display_name: "Rust-Analyzer settings for Visual Studio Code",
+                enables: &[],
+                disables: &[],
+                chips: &[],
+            }),
+        ],
+    }),
 ];
 
 #[derive(Parser, Debug)]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -196,7 +196,7 @@ impl App {
                             self.repository.up();
                             self.state.select(Some(0));
                         }
-                        Char('l') | Right | Enter => {
+                        Char('l') | Char(' ') | Right | Enter => {
                             let selected = self.state.selected().unwrap_or_default();
                             if self.repository.is_option(selected) {
                                 self.repository.toggle_current(selected);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -69,7 +69,10 @@ impl Repository {
 
                 let currently_selected = self.selected.clone();
                 for option in currently_selected {
-                    let option = find_option(option, self.options).unwrap();
+                    let Some(option) = find_option(&option, self.options) else {
+                        ratatui::restore();
+                        panic!("option not found");
+                    };
                     for enable in option.enables {
                         if !self.selected.contains(&enable.to_string()) {
                             self.selected.push(enable.to_string());
@@ -77,7 +80,10 @@ impl Repository {
                     }
                     for disable in option.disables {
                         if self.selected.contains(&disable.to_string()) {
-                            let idx = self.selected.iter().position(|v| v == disable).unwrap();
+                            let Some(idx) = self.selected.iter().position(|v| v == disable) else {
+                                ratatui::restore();
+                                panic!("disable option not found");
+                            };
                             self.selected.remove(idx);
                         }
                     }
@@ -122,13 +128,16 @@ impl Repository {
 }
 
 fn find_option(
-    option: String,
+    option: &str,
     options: &'static [GeneratorOptionItem],
 ) -> Option<&'static GeneratorOption> {
     for item in options {
         match item {
             GeneratorOptionItem::Category(category) => {
-                return find_option(option, category.options)
+                let found_option = find_option(option, category.options);
+                if found_option.is_some() {
+                    return found_option;
+                }
             }
             GeneratorOptionItem::Option(item) => {
                 if item.name == option {

--- a/template/.helix/languages.toml
+++ b/template/.helix/languages.toml
@@ -1,0 +1,7 @@
+#INCLUDEFILE helix
+[[language]]
+name = "rust"
+
+[language-server.rust-analyzer.config]
+check.allTargets = false
+cargo.target = "riscv32imac-unknown-none-elf"

--- a/template/.helix/languages.toml
+++ b/template/.helix/languages.toml
@@ -4,4 +4,5 @@ name = "rust"
 
 [language-server.rust-analyzer.config]
 check.allTargets = false
+#REPLACE riscv32imac-unknown-none-elf rust_target
 cargo.target = "riscv32imac-unknown-none-elf"

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -1,3 +1,4 @@
+//INCLUDEFILE vscode
 {
     "rust-analyzer.cargo.allTargets": false,
     //REPLACE riscv32imac-unknown-none-elf rust_target


### PR DESCRIPTION
Mostly fixes #42

I will admit I don't know how to configure neovim, but I've added support for the editor I use anyway.
I could have added editors under the `optional` section but i felt as if having deeper nested selection was a worse experience. Can move it if you want me to

I snuck in space to select as well as that is quite a common key in these terminal interfaces.