### PR TITLE
Udpate to latest release and various fixes/improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,15 +61,19 @@ jobs:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
           components: clippy,rustfmt,rust-src
 
+      # //Define a new environment variable called toolchain
+      - if: ${{ contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.chip) }}
+        run: echo "TOOLCHAIN=+esp" >> $GITHUB_ENV
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Generate and check project
         if: github.event_name != 'schedule' &&  !inputs.all_combinations
-        run: cd xtask && cargo run -- check ${{ matrix.chip }}
+        run: cd xtask && cargo ${{ env.TOOLCHAIN }} run -- check ${{ matrix.chip }}
 
       - name: Generate and check project (all combinations)
         if: github.event_name == 'schedule' ||  inputs.all_combinations
-        run: cd xtask && cargo run -- check ${{ matrix.chip }} --all-combinations
+        run: cd xtask && cargo ${{ env.TOOLCHAIN }} run -- check ${{ matrix.chip }} --all-combinations
 
   # --------------------------------------------------------------------------
   # Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Remember position when entering a sub-menu to restore state on exit.
+- Update dependencies to latest esp-hal releases.
+- Use `systimer` instead of `timg` in embassy templates for all targets but ESP32
 
 ### Removed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,6 +259,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         args.option.clone()
     };
 
+    selected.push(args.chip.to_string());
+
     selected.push(if args.chip.is_riscv() {
         "riscv".to_string()
     } else {

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -48,7 +48,6 @@ esp-wifi = { version = "0.11.0", default-features=false, features = [
     "utils",
     #IF option("wifi")
     "wifi",
-    "wifi-default",
     #ENDIF
     #IF option("ble")
     "ble",

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-esp-backtrace = { version = "0.14.1", features = [
+esp-backtrace = { version = "0.14.2", features = [
     #REPLACE esp32c6 mcu
     "esp32c6",
     "exception-handler",
@@ -17,7 +17,7 @@ esp-backtrace = { version = "0.14.1", features = [
     #ENDIF
 ]}
 
-esp-hal = { version = "0.21.0", features = [
+esp-hal = { version = "0.22.0", features = [
     #REPLACE esp32c6 mcu
     "esp32c6",
     #IF option("probe-rs")
@@ -42,7 +42,7 @@ embassy-net = { version = "0.4.0", features = [ "tcp", "udp", "dhcpv4", "medium-
 #ENDIF
 #ENDIF
 
-esp-wifi = { version = "0.10.1", default-features=false, features = [
+esp-wifi = { version = "0.11.0", default-features=false, features = [
     #REPLACE esp32c6 mcu
     "esp32c6",
     "phy-enable-usb",
@@ -97,7 +97,7 @@ embassy-executor = { version = "0.6.0",  features = [
 ] }
 embassy-time     = { version = "0.3.1",  features = ["generic-queue-8"] }
 #REPLACE esp32c6 mcu
-esp-hal-embassy  = { version = "0.4.0",  features = ["esp32c6"] }
+esp-hal-embassy  = { version = "0.5.0",  features = ["esp32c6"] }
 static_cell      = { version = "2.1.0",  features = ["nightly"] }
 #ENDIF
 

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -45,7 +45,6 @@ embassy-net = { version = "0.4.0", features = [ "tcp", "udp", "dhcpv4", "medium-
 esp-wifi = { version = "0.11.0", default-features=false, features = [
     #REPLACE esp32c6 mcu
     "esp32c6",
-    "phy-enable-usb",
     "utils",
     #IF option("wifi")
     "wifi",

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -59,12 +59,6 @@ esp-wifi = { version = "0.11.0", default-features=false, features = [
     #IF !option("probe-rs")
     "log",
     #ENDIF
-    #IF option("embassy")
-    "async",
-    #IF option("wifi")
-    "embassy-net",
-    #ENDIF
-    #ENDIF
 ] }
 heapless = { version = "0.8.0", default-features = false }
 smoltcp = { version = "0.11.0", default-features = false, features = [

--- a/template/build.rs
+++ b/template/build.rs
@@ -1,11 +1,5 @@
 fn main() {
     println!("cargo:rustc-link-arg-bins=-Tlinkall.x");
-    //IF option("wifi")
-    println!("cargo:rustc-link-arg-bins=-Trom_functions.x");
-    //ENDIF
-    //IF option("ble")
-    println!("cargo:rustc-link-arg-bins=-Trom_functions.x");
-    //ENDIF
     //IF option("probe-rs")
     println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
     //ENDIF

--- a/template/src/bin/async_main.rs
+++ b/template/src/bin/async_main.rs
@@ -35,14 +35,21 @@ async fn main(spawner: Spawner) {
     esp_println::logger::init_logger_from_env();
     //ENDIF
 
-    let timg0 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0);
-    esp_hal_embassy::init(timg0.timer0);
+    //IF !option("esp32")
+    let timer0 = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER)
+        .split::<esp_hal::timer::systimer::Target>();
+    esp_hal_embassy::init(timer0.alarm0);
+    //ELSE
+    let timer0 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1);
+    esp_hal_embassy::init(timer0.timer0);
+    //ENDIF
+
     info!("Embassy initialized!");
 
     //IF option("wifi") || option("ble")
-    let timg1 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1);
+    let timer1 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0);
     let _init = esp_wifi::init(
-        timg1.timer0,
+        timer1.timer0,
         esp_hal::rng::Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
     )

--- a/template/src/bin/async_main.rs
+++ b/template/src/bin/async_main.rs
@@ -56,13 +56,6 @@ async fn main(spawner: Spawner) {
     .unwrap();
     //ENDIF
 
-    //IF option("wifi")
-    let _wifi = peripherals.WIFI;
-    //ENDIF
-    //IF option("ble")
-    let _bluetooth = peripherals.BT;
-    //ENDIF
-
     // TODO: Spawn some tasks
     let _ = spawner;
 

--- a/template/src/bin/async_main.rs
+++ b/template/src/bin/async_main.rs
@@ -42,17 +42,18 @@ async fn main(spawner: Spawner) {
     //IF option("wifi") || option("ble")
     let timg1 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1);
     let _init = esp_wifi::init(
-        //IF option("wifi")
-        esp_wifi::EspWifiInitFor::Wifi,
-        //ENDIF
-        //IF option("ble")
-        //+esp_wifi::EspWifiInitFor::Ble,
-        //ENDIF
         timg1.timer0,
         esp_hal::rng::Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
     )
     .unwrap();
+    //ENDIF
+
+    //IF option("wifi")
+    let _wifi = peripherals.WIFI;
+    //ENDIF
+    //IF option("ble")
+    let _bluetooth = peripherals.BT;
     //ENDIF
 
     // TODO: Spawn some tasks

--- a/template/src/bin/main.rs
+++ b/template/src/bin/main.rs
@@ -37,17 +37,18 @@ fn main() -> ! {
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     let _init = esp_wifi::init(
-        //IF option("wifi")
-        esp_wifi::EspWifiInitFor::Wifi,
-        //ENDIF
-        //IF option("ble")
-        //+esp_wifi::EspWifiInitFor::Ble,
-        //ENDIF
         timg0.timer0,
         esp_hal::rng::Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
     )
     .unwrap();
+    //ENDIF
+
+    //IF option("wifi")
+    let _wifi = peripherals.WIFI;
+    //ENDIF
+    //IF option("ble")
+    let _bluetooth = peripherals.BT;
     //ENDIF
 
     let delay = Delay::new();

--- a/template/src/bin/main.rs
+++ b/template/src/bin/main.rs
@@ -44,13 +44,6 @@ fn main() -> ! {
     .unwrap();
     //ENDIF
 
-    //IF option("wifi")
-    let _wifi = peripherals.WIFI;
-    //ENDIF
-    //IF option("ble")
-    let _bluetooth = peripherals.BT;
-    //ENDIF
-
     let delay = Delay::new();
     loop {
         info!("Hello world!");


### PR DESCRIPTION
This started as a PR to upgrade the deps to the latest dependencies but ended up being a bit more:
- Updates deps to latest esp-hal releases and adapt code
- CI was not failing when one option combination failed, now it bails
- Use systimer in embassy template for all targets but esp32

CI run checking all combinations: https://github.com/SergioGasquez/esp-generate/actions/runs/11950996040