### PR TITLE
Support COEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Allow selecting WiFi and BLE at the same time
 
 ### Fixed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ static OPTIONS: &[GeneratorOptionItem] = &[
         name: "wifi",
         display_name: "Enables Wi-Fi via the `esp-wifi` crate. Requires `alloc`.",
         enables: &["alloc"],
-        disables: &["ble"],
+        disables: &[],
         chips: &[
             Chip::Esp32,
             Chip::Esp32c2,
@@ -111,7 +111,7 @@ static OPTIONS: &[GeneratorOptionItem] = &[
         name: "ble",
         display_name: "Enables BLE via the `esp-wifi` crate. Requires `alloc`.",
         enables: &["alloc"],
-        disables: &["wifi"],
+        disables: &[],
         chips: &[
             Chip::Esp32,
             Chip::Esp32c2,
@@ -440,11 +440,6 @@ fn process_options(args: &Args) {
                 process::exit(-1);
             }
         }
-    }
-
-    if args.option.contains(&String::from("ble")) && args.option.contains(&String::from("wifi")) {
-        log::error!("Options 'ble' and 'wifi' are mutually exclusive");
-        process::exit(-1);
     }
 }
 

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -52,6 +52,9 @@ esp-wifi = { version = "0.11.0", default-features=false, features = [
     #IF option("ble")
     "ble",
     #ENDIF
+    #IF option("wifi") && option("ble")
+    "coex",
+    #ENDIF
     "esp-alloc",
     #IF option("probe-rs")
     #+"defmt",
@@ -92,6 +95,7 @@ embassy-time     = { version = "0.3.1",  features = ["generic-queue-8"] }
 esp-hal-embassy  = { version = "0.5.0",  features = ["esp32c6"] }
 static_cell      = { version = "2.1.0",  features = ["nightly"] }
 #ENDIF
+critical-section = "1.2.0"
 
 [profile.dev]
 # Rust debug is too slow.


### PR DESCRIPTION
Closes #59 

In the very beginning it was easier to not support the coex - case (because IF conditions were very inflexible). Now it's easy to support it
