### PR TITLE
Generator version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update the resulting binary name (#62)
+- Include version of `esp-generate` in the generated code (#67)
+- Use rustc-link-arg instead of rustc-link-arg-bin (#67)
 
 ### Fixed
 - Verify the required options are provided (#65)

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,6 +295,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         ("project-name".to_string(), args.name.clone()),
         ("mcu".to_string(), args.chip.to_string()),
         ("wokwi-board".to_string(), wokwi_devkit.to_string()),
+        (
+            "generate-version".to_string(),
+            env!("CARGO_PKG_VERSION").to_string(),
+        ),
     ];
 
     variables.push(("rust_target".to_string(), args.chip.target().to_string()));

--- a/template/build.rs
+++ b/template/build.rs
@@ -1,6 +1,6 @@
 fn main() {
-    println!("cargo:rustc-link-arg-bins=-Tlinkall.x");
+    println!("cargo:rustc-link-arg=-Tlinkall.x");
     //IF option("probe-rs")
-    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
     //ENDIF
 }

--- a/template/src/bin/async_main.rs
+++ b/template/src/bin/async_main.rs
@@ -21,6 +21,9 @@ extern crate alloc;
 
 #[main]
 async fn main(spawner: Spawner) {
+    //REPLACE generate-version generate-version
+    // generator version: generate-version
+
     let peripherals = esp_hal::init({
         let mut config = esp_hal::Config::default();
         config.cpu_clock = CpuClock::max();

--- a/template/src/bin/main.rs
+++ b/template/src/bin/main.rs
@@ -21,6 +21,9 @@ extern crate alloc;
 
 #[entry]
 fn main() -> ! {
+    //REPLACE generate-version generate-version
+    // generator version: generate-version
+
     //IF option("wifi") || option("ble")
     let peripherals = esp_hal::init({
     //ELSE
@@ -30,7 +33,6 @@ fn main() -> ! {
         config.cpu_clock = CpuClock::max();
         config
     });
-
     //IF !option("probe-rs")
     esp_println::logger::init_logger_from_env();
     //ENDIF


### PR DESCRIPTION
- include version of `esp-generate` in the generated code
- use `rustc-link-arg` instead of `rustc-link-arg-bin`