### PR TITLE
Use stable toolchain for rust-analyzer on xtensa targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Verify the required options are provided (#65)
+- Use stable toolchain for rust-analyzer on xtensa targets (#69)
 
 ### Removed
 

--- a/template/.helix/languages.toml
+++ b/template/.helix/languages.toml
@@ -11,3 +11,7 @@ environment.RUSTUP_TOOLCHAIN = "stable"
 check.allTargets = false
 #REPLACE riscv32imac-unknown-none-elf rust_target
 cargo.target = "riscv32imac-unknown-none-elf"
+#IF option("xtensa")
+check.extraEnv.RUSTUP_TOOLCHAIN = "esp"
+cargo.extraEnv.RUSTUP_TOOLCHAIN = "esp"
+#ENDIF

--- a/template/.helix/languages.toml
+++ b/template/.helix/languages.toml
@@ -2,6 +2,11 @@
 [[language]]
 name = "rust"
 
+#IF option("xtensa")
+[language-server.rust-analyzer]
+environment.RUSTUP_TOOLCHAIN = "stable"
+
+#ENDIF
 [language-server.rust-analyzer.config]
 check.allTargets = false
 #REPLACE riscv32imac-unknown-none-elf rust_target

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -7,5 +7,11 @@
   "rust-analyzer.server.extraEnv": {
     "RUSTUP_TOOLCHAIN": "stable"
   },
+  "rust-analyzer.check.extraEnv": {
+    "RUSTUP_TOOLCHAIN": "esp"
+  },
+  "rust-analyzer.cargo.extraEnv": {
+    "RUSTUP_TOOLCHAIN": "esp"
+  },
   //ENDIF
 }

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -1,6 +1,11 @@
 //INCLUDEFILE vscode
 {
-    "rust-analyzer.cargo.allTargets": false,
-    //REPLACE riscv32imac-unknown-none-elf rust_target
-    "rust-analyzer.cargo.target": "riscv32imac-unknown-none-elf",
+  "rust-analyzer.cargo.allTargets": false,
+  //REPLACE riscv32imac-unknown-none-elf rust_target
+  "rust-analyzer.cargo.target": "riscv32imac-unknown-none-elf",
+  //IF option("xtensa")
+  "rust-analyzer.server.extraEnv": {
+    "RUSTUP_TOOLCHAIN": "stable"
+  },
+  //ENDIF
 }


### PR DESCRIPTION
It seems that rust-analyzer doesn't support custom toolchains, but the documentation suggests adding an override such that rust-analzer runs on the stable toolchain: https://rust-analyzer.github.io/manual.html#toolchain.

