### PR TITLE
Fix dev-container templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Verify the required options are provided (#65)
+- Added missing template substitution in devcontainer.json (#70)
 
 ### Removed
 

--- a/template/.devcontainer/Dockerfile
+++ b/template/.devcontainer/Dockerfile
@@ -54,9 +54,6 @@ RUN if [ -n "${GITHUB_TOKEN}" ]; then export GITHUB_TOKEN=${GITHUB_TOKEN}; fi  \
     --log-level debug \
     --export-file /home/${CONTAINER_USER}/export-esp.sh
 
-# Set default toolchain
-RUN rustup default {{ toolchain }}
-
 # Activate ESP environment
 RUN echo "source /home/${CONTAINER_USER}/export-esp.sh" >> ~/.bashrc
 

--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -1,14 +1,17 @@
 //INCLUDEFILE dev-container
 {
-  "name": "{{ crate_name }}",
+  //REPLACE project-name project-name
+  "name": "project-name",
   // Select between image and build properties to pull or build the image.
-  // "image": "docker.io/espressif/idf-rust:{{ mcu }}_latest",
+  //REPLACE mcu mcu
+  // "image": "docker.io/espressif/idf-rust:mcu_latest",
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
       "CONTAINER_USER": "esp",
       "CONTAINER_GROUP": "esp",
-      "ESP_BOARD": "{{ mcu }}"
+      //REPLACE mcu mcu
+      "ESP_BOARD": "mcu"
     }
   },
   "customizations": {
@@ -44,6 +47,8 @@
     8000,
     3333
   ],
-  "workspaceMount": "source=${localWorkspaceFolder},target=/home/esp/{{ crate_name }},type=bind,consistency=cached",
-  "workspaceFolder": "/home/esp/{{ crate_name }}"
+  //REPLACE project-name project-name
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/esp/project-name,type=bind,consistency=cached",
+  //REPLACE project-name project-name
+  "workspaceFolder": "/home/esp/project-name"
 }


### PR DESCRIPTION
## Problem
The `dev-container` option  (set using `esp-generate --chip esp32 -o dev-container your-project`) does not generate a valid dev-container configuration. The templated parameters are never substituted, which leads to syntax errors, when opening the container. 

This PR updates the dev-container.json file template to use the key/value based substitution found in other files.