### PR TITLE
Format dependencies

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -25,7 +25,6 @@ esp-backtrace = { version = "0.14.2", features = [
     "println",
     #ENDIF
 ]}
-
 esp-hal = { version = "0.22.0", features = [
     #REPLACE esp32c6 mcu
     "esp32c6",
@@ -43,14 +42,12 @@ esp-alloc = { version = "0.5.0" }
 #ENDIF
 #IF option("wifi") || option("ble")
 embedded-io = "0.6.1"
-
 #IF option("embassy")
 embedded-io-async = "0.6.1"
 #IF option("wifi")
 embassy-net = { version = "0.4.0", features = [ "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 #ENDIF
 #ENDIF
-
 esp-wifi = { version = "0.11.0", default-features=false, features = [
     #REPLACE esp32c6 mcu
     "esp32c6",
@@ -86,7 +83,7 @@ smoltcp = { version = "0.11.0", default-features = false, features = [
 ] }
 #ENDIF
 #IF option("ble")
-#+ bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "a5148d8ae679e021b78f53fd33afb8bb35d0b62e", features = [ "macros", "async"] }
+#+bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "a5148d8ae679e021b78f53fd33afb8bb35d0b62e", features = [ "macros", "async"] }
 #ENDIF
 #IF option("probe-rs")
 #+defmt            = "0.3.8"


### PR DESCRIPTION
Removed some lines between dependencies and empty space before `bleps`