### PR TITLE
Use published `edge-*` crates

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -46,7 +46,7 @@ embedded-io = "0.6.1"
 #IF option("embassy")
 embedded-io-async = "0.6.1"
 #IF option("wifi")
-embassy-net = { version = "0.4.0", features = [ "tcp", "udp", "dhcpv4", "medium-ethernet"] }
+embassy-net = { version = "0.6.0", features = [ "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 #ENDIF
 #ENDIF
 esp-wifi = { version = "0.12.0", default-features=false, features = [
@@ -73,12 +73,19 @@ esp-wifi = { version = "0.12.0", default-features=false, features = [
 heapless = { version = "0.8.0", default-features = false }
 smoltcp = { version = "0.12.0", default-features = false, features = [
     "medium-ethernet",
+    "multicast",
+    "proto-dhcpv4",
+    "proto-dns",
+    "proto-ipv4",
+    "socket-dns",
     "socket-raw",
+    "socket-tcp",
+    "socket-udp",
+    "socket-icmp",
 ] }
-edge-dhcp = { version = "0.5.0" }
-edge-raw = { version = "0.5.0" }
-edge-nal = { version = "0.5.0" }
-edge-nal-embassy = { version = "0.5.0" }
+#IF option("embassy")
+# for more networking protocol support see https://crates.io/crates/edge-net
+#ENDIF
 #ENDIF
 #IF option("ble")
 #+bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "a5148d8ae679e021b78f53fd33afb8bb35d0b62e", features = [ "macros", "async"] }

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -75,10 +75,10 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
     "medium-ethernet",
     "socket-raw",
 ] }
-edge-dhcp = { version = "0.5.0", git = "https://github.com/bugadani/edge-net", rev = "b72678e15bb7c6e72809df235778bb7b48ac146d" }
-edge-raw = { version = "0.5.0", git = "https://github.com/bugadani/edge-net", rev = "b72678e15bb7c6e72809df235778bb7b48ac146d" }
-edge-nal = { version = "0.5.0", git = "https://github.com/bugadani/edge-net", rev = "b72678e15bb7c6e72809df235778bb7b48ac146d" }
-edge-nal-embassy = { version = "0.5.0", git = "https://github.com/bugadani/edge-net", rev = "b72678e15bb7c6e72809df235778bb7b48ac146d" }
+edge-dhcp = { version = "0.5.0" }
+edge-raw = { version = "0.5.0" }
+edge-nal = { version = "0.5.0" }
+edge-nal-embassy = { version = "0.5.0" }
 #ENDIF
 #IF option("ble")
 #+bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "a5148d8ae679e021b78f53fd33afb8bb35d0b62e", features = [ "macros", "async"] }


### PR DESCRIPTION
The `edge-*` crates got new releases so we can use them instead of the git revs.

However, I wonder if we should include them at all by default?

e.g. `edge-dhcp` is only useful for AP but I assume that's not very common.

Maybe we should add a hint like `# for more networking protocol support visit https://crates.io/crates/edge-net` instead?

And it seems those crates are async only - so we shouldn't include them (or the hint) if we don't generate for async?

I'm open to suggestions and happy to change this PR accordingly
