### PR TITLE
Minor CI cleanups

### DIFF
--- a/template/.github/workflows/rust_ci.yml
+++ b/template/.github/workflows/rust_ci.yml
@@ -10,7 +10,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+#IF option("xtensa")
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#ENDIF
 
 jobs:
   rust-checks:
@@ -23,7 +25,7 @@ jobs:
           - command: build
             args: --release
           - command: fmt
-            args: --all -- --check --color always
+            args: --all -- --check
           - command: clippy
             args: --all-features --workspace -- -D warnings
     steps:


### PR DESCRIPTION
- `GITHUB_TOKEN` is only required when used `xtensa-toolchain` action
- `--color always` is redundant, we have `CARGO_TERM_COLOR: always`