### PR TITLE
Fix the extraEnv log in the VS Code settings file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the logic for setting toolchain in `.vscode/settings.json` (#80)
+
 ### Removed
 
 ## [0.2.2] - 2025-01-16
 
 ### Added
+
 - The resulting `Cargo.toml` is now formated with Taplo (#72)
 
 ### Changed
+
 - Update the resulting binary name (#62)
 - Include version of `esp-generate` in the generated code (#67)
 - Use `rustc-link-arg` instead of `rustc-link-arg-bin` (#67)
 
 ### Fixed
+
 - Verify the required options are provided (#65)
 - Use `stable` toolchain for Rust Analyzer on Xtensa targets (#69)
 - Added missing template substitution in `devcontainer.json` (#70)
@@ -33,20 +38,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2024-11-26
 
 ### Changed
+
 - Allow selecting WiFi and BLE at the same time (#60)
 
 ### Fixed
+
 - Don't deselect just selected option (#58)
 - Added missing init code in non-async template (#57)
 
 ## [0.2.0] - 2024-11-21
 
 ### Added
+
 - Added editor selection. Currently only helix and vscode
 - Before quitting the TUI, it ask for user confirmation
 - Show a hint where to find examples
 
 ### Changed
+
 - Remember position when entering a sub-menu to restore state on exit.
 - Update dependencies to latest esp-hal releases.
 - Use `systimer` instead of `timg` in embassy templates for all targets but ESP32

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -4,14 +4,12 @@
   //REPLACE riscv32imac-unknown-none-elf rust_target
   "rust-analyzer.cargo.target": "riscv32imac-unknown-none-elf",
   //IF option("xtensa")
-  "rust-analyzer.server.extraEnv": {
-    "RUSTUP_TOOLCHAIN": "stable"
-  },
   "rust-analyzer.check.extraEnv": {
     "RUSTUP_TOOLCHAIN": "esp"
   },
-  "rust-analyzer.cargo.extraEnv": {
-    "RUSTUP_TOOLCHAIN": "esp"
-  },
+  //ELSE
+  "rust-analyzer.server.extraEnv": {
+    "RUSTUP_TOOLCHAIN": "stable"
+  }
   //ENDIF
 }


### PR DESCRIPTION
Fixes #79 (I think)

Not super familiar with this conditional syntax in the templates, but based on local testing at least it seems to work as expected now. @SergioGasquez or @bjoernQ can you confirm please?