### PR TITLE
Check rustc+cargo, espflash, probe-rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
--  Added a version checker that prints a wanr message if not using latest esp-generate version (#87)
+- Added a version checker that prints a warn message if not using latest esp-generate version (#87)
+
+- After generating the project the tool now checks the rust version, espflash version and probe-rs version (#88)
+
 ### Changed
 - Update `probe-rs run` arguments (#90)
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,0 +1,88 @@
+use core::str;
+
+use esp_metadata::Chip;
+
+struct Version {
+    major: u8,
+    minor: u8,
+    patch: u8,
+}
+
+enum CheckResult {
+    Ok,
+    WrongVersion,
+    NotFound,
+}
+
+pub fn check(chip: Chip) {
+    let rust_version = get_version(
+        "cargo",
+        if chip.is_xtensa() {
+            &["+esp"]
+        } else {
+            &["+stable"]
+        },
+    );
+
+    let espflash_version = get_version("espflash", &[]);
+    let probers_version = get_version("probe-rs", &[]);
+
+    println!("\nChecking installed versions");
+    print_result("Rust", check_version(rust_version, 1, 84, 0));
+    print_result("espflash", check_version(espflash_version, 3, 3, 0));
+    print_result("probe-rs", check_version(probers_version, 0, 25, 0));
+}
+
+fn print_result(name: &str, check_result: CheckResult) {
+    match check_result {
+        CheckResult::Ok => println!("🆗 {}", name),
+        CheckResult::WrongVersion => println!("🛑 {}", name),
+        CheckResult::NotFound => println!("❌ {}", name),
+    }
+}
+
+fn check_version(version: Option<Version>, major: u8, minor: u8, patch: u8) -> CheckResult {
+    match version {
+        Some(version) => {
+            if version.major >= major && version.minor >= minor && version.patch >= patch {
+                CheckResult::Ok
+            } else {
+                CheckResult::WrongVersion
+            }
+        }
+        None => CheckResult::NotFound,
+    }
+}
+
+fn get_version(cmd: &str, args: &[&str]) -> Option<Version> {
+    let output = std::process::Command::new(cmd)
+        .args(args)
+        .arg("--version")
+        .output();
+
+    match output {
+        Ok(output) => {
+            if output.status.success() {
+                if let Ok(output) = str::from_utf8(&output.stdout) {
+                    let mut parts = output.split_whitespace();
+                    let _name = parts.next();
+                    let version = parts.next();
+                    if let Some(version) = version {
+                        let mut version = version.split(&['.', '-', '+']);
+                        let major = version.next().unwrap().parse::<u8>().unwrap();
+                        let minor = version.next().unwrap().parse::<u8>().unwrap();
+                        let patch = version.next().unwrap().parse::<u8>().unwrap();
+                        return Some(Version {
+                            major,
+                            minor,
+                            patch,
+                        });
+                    }
+                }
+            }
+
+            None
+        }
+        Err(_) => None,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use esp_metadata::Chip;
 use taplo::formatter::Options;
 use update_informer::{registry, Check};
 
+mod check;
 mod template_files;
 mod tui;
 
@@ -374,6 +375,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     } else {
         log::warn!("Current directory is already in a git repository, skipping git initialization");
     }
+
+    check::check(args.chip);
 
     Ok(())
 }


### PR DESCRIPTION
After generation this will show s.th. like this

![image](https://github.com/user-attachments/assets/cdb6d173-cdad-4f5e-9857-3d61705144f7)

It's just to hint the user in case of any problems - they can still update / install tools after the project is generated.

Closes #63