### PR TITLE
Make linker errors more helpful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - After generating the project the tool now checks the rust version, espflash version and probe-rs version (#88)
 
-- Be more helpful in case of common linker errors
+- Be more helpful in case of common linker errors (#94)
 
 ### Changed
 - Update `probe-rs run` arguments (#90)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - After generating the project the tool now checks the rust version, espflash version and probe-rs version (#88)
 
+- Be more helpful in case of common linker errors
+
 ### Changed
 - Update `probe-rs run` arguments (#90)
 

--- a/template/build.rs
+++ b/template/build.rs
@@ -1,7 +1,52 @@
 fn main() {
+    linker_be_nice();
     //IF option("probe-rs")
     println!("cargo:rustc-link-arg=-Tdefmt.x");
     //ENDIF
     // make sure linkall.x is the last linker script (otherwise might cause problems with flip-link)
     println!("cargo:rustc-link-arg=-Tlinkall.x");
+}
+
+fn linker_be_nice() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() > 1 {
+        let kind = &args[1];
+        let what = &args[2];
+
+        match kind.as_str() {
+            "undefined-symbol" => match what.as_str() {
+                "_defmt_timestamp" => {
+                    eprintln!();
+                    eprintln!("💡 `defmt` not found - make sure `defmt.x` is added as a linker script and you have included `use defmt_rtt as _;`");
+                    eprintln!();
+                }
+                "_stack_start" => {
+                    eprintln!();
+                    eprintln!("💡 Is the linker script `linkall.x` missing?");
+                    eprintln!();
+                }
+                _ => (),
+            },
+            // we don't have anything helpful for "missing-lib" yet
+            _ => {
+                std::process::exit(1);
+            }
+        }
+
+        std::process::exit(0);
+    }
+
+    //IF option("xtensa")
+    println!(
+        "cargo:rustc-link-arg=-Wl,--error-handling-script={}",
+        std::env::current_exe().unwrap().display()
+    );
+    //ENDIF
+
+    //IF option("riscv")
+    println!(
+        "cargo:rustc-link-arg=--error-handling-script={}",
+        std::env::current_exe().unwrap().display()
+    );
+    //ENDIF
 }


### PR DESCRIPTION
I stumbled upon this "by accident" but thought it might be a good idea - but maybe I'm just a little bit too excited about this so if we don't think it's useful it's fine.

It will look like this

![image](https://github.com/user-attachments/assets/74ea2755-4303-47b2-b501-56839b304ecd)

While users can't run into it with a freshly generated project they might add and change things which might make them run into it

I guess there are more things that could be helpful - I just didn't want to waste too much time with something we don't think is useful
