### PR TITLE
Moar options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ cargo install esp-generate
 - `ble`: Enables BLE via the `esp-wifi` crate; requires `alloc`.
 - `embassy`: Adds `embassy` framework support.
 - `probe-rs`: Enables `defmt` and flashes using `probe-rs` instead of `espflash`.
+- `logging`: Logging frontend and backend options
+  - `log-backend-defmt-rtt`: Uses `defmt-rtt` as the log backend.
+  - `log-backend-esp-println`: Uses `esp-println` as the log backend. Can be used without a log frontend.
+  - `log-frontend-log`: Uses the `log` crate as the logging API. Requires `esp-println` as the backend.
+  - `log-frontend-defmt`: Uses the `defmt` crate as the logging API. Can be used with both backends.
+- `panic`: Panic handler options
+  - `panic-esp-backtrace`: Use `esp-backtrace` to handle panics.
 - `optional`: Enables the following set of options:
   - `wokwi`: Adds support for Wokwi simulation using [VS Code Wokwi extension].
   - `dev-container`: Adds support for [VS Code Dev Containers] and [GitHub Codespaces].

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,14 +99,14 @@ impl GeneratorOptionItem {
 static OPTIONS: &[GeneratorOptionItem] = &[
     GeneratorOptionItem::Option(GeneratorOption {
         name: "alloc",
-        display_name: "Enables allocations via the `esp-alloc` crate.",
+        display_name: "Enable allocations via the `esp-alloc` crate.",
         enables: &[],
         disables: &[],
         chips: &[],
     }),
     GeneratorOptionItem::Option(GeneratorOption {
         name: "wifi",
-        display_name: "Enables Wi-Fi via the `esp-wifi` crate. Requires `alloc`.",
+        display_name: "Enable Wi-Fi via the `esp-wifi` crate. Requires `alloc`.",
         enables: &["alloc"],
         disables: &[],
         chips: &[
@@ -120,7 +120,7 @@ static OPTIONS: &[GeneratorOptionItem] = &[
     }),
     GeneratorOptionItem::Option(GeneratorOption {
         name: "ble",
-        display_name: "Enables BLE via the `esp-wifi` crate. Requires `alloc`.",
+        display_name: "Enable BLE via the `esp-wifi` crate. Requires `alloc`.",
         enables: &["alloc"],
         disables: &[],
         chips: &[
@@ -134,7 +134,7 @@ static OPTIONS: &[GeneratorOptionItem] = &[
     }),
     GeneratorOptionItem::Option(GeneratorOption {
         name: "embassy",
-        display_name: "Adds `embassy` framework support.",
+        display_name: "Add `embassy` framework support.",
         enables: &[],
         disables: &[],
         chips: &[],
@@ -152,7 +152,7 @@ static OPTIONS: &[GeneratorOptionItem] = &[
         options: &[
             GeneratorOptionItem::Option(GeneratorOption {
                 name: "wokwi",
-                display_name: "Adds support for Wokwi simulation using VS Code Wokwi extension.",
+                display_name: "Add support for Wokwi simulation using VS Code Wokwi extension.",
                 enables: &[],
                 disables: &[],
                 chips: &[
@@ -166,14 +166,14 @@ static OPTIONS: &[GeneratorOptionItem] = &[
             }),
             GeneratorOptionItem::Option(GeneratorOption {
                 name: "dev-container",
-                display_name: "Adds support for VS Code Dev Containers and GitHub Codespaces.",
+                display_name: "Add support for VS Code Dev Containers and GitHub Codespaces.",
                 enables: &[],
                 disables: &[],
                 chips: &[],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
                 name: "ci",
-                display_name: "Adds GitHub Actions support with some basics checks.",
+                display_name: "Add GitHub Actions support with some basic checks.",
                 enables: &[],
                 disables: &[],
                 chips: &[],
@@ -186,14 +186,14 @@ static OPTIONS: &[GeneratorOptionItem] = &[
         options: &[
             GeneratorOptionItem::Option(GeneratorOption {
                 name: "helix",
-                display_name: "Rust-Analyzer settings for Helix Editor",
+                display_name: "Add rust-analyzer settings for Helix Editor",
                 enables: &[],
                 disables: &[],
                 chips: &[],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
                 name: "vscode",
-                display_name: "Rust-Analyzer settings for Visual Studio Code",
+                display_name: "Add rust-analyzer settings for Visual Studio Code",
                 enables: &[],
                 disables: &[],
                 chips: &[],

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,10 +141,67 @@ static OPTIONS: &[GeneratorOptionItem] = &[
     }),
     GeneratorOptionItem::Option(GeneratorOption {
         name: "probe-rs",
-        display_name: "Enables `defmt` and flashes using `probe-rs` instead of `espflash`.",
-        enables: &[],
+        display_name: "Use `probe-rs` instead of `espflash` for flashing and logging.",
+        enables: &["log-backend-defmt-rtt"],
         disables: &[],
         chips: &[],
+    }),
+    GeneratorOptionItem::Category(GeneratorOptionCategory {
+        name: "logging",
+        display_name: "Logging options",
+        options: &[
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "log-backend-defmt-rtt",
+                display_name: "Use `defmt-rtt` as the log backend.",
+                enables: &["probe-rs"],
+                disables: &["log-backend-esp-println"],
+                chips: &[],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "log-backend-esp-println",
+                display_name:
+                    "Use `esp-println` as the log backend. Can be used without a log frontend.",
+                enables: &[],
+                disables: &["log-backend-defmt-rtt"],
+                chips: &[],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "log-frontend-log",
+                display_name:
+                    "Use the `log` crate as the logging API. Requires `esp-println` as the backend.",
+                enables: &["log-backend-esp-println"],
+                disables: &["log-frontend-defmt", "log-backend-defmt-rtt"],
+                chips: &[],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "log-frontend-defmt",
+                display_name:
+                    "Use the `defmt` crate as the logging API. Can be used with both backends.",
+                enables: &[],
+                disables: &["log-frontend-log"],
+                chips: &[],
+            }),
+        ],
+    }),
+    GeneratorOptionItem::Category(GeneratorOptionCategory {
+        name: "panic",
+        display_name: "Panic handling options",
+        options: &[
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "panic-esp-backtrace",
+                display_name: "Use `esp-backtrace`.",
+                enables: &[],
+                disables: &["panic-panic-probe"],
+                chips: &[],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "panic-panic-probe",
+                display_name: "Use `panic-probe`. Requires `probe-rs`.",
+                enables: &["probe-rs"],
+                disables: &["panic-esp-backtrace"],
+                chips: &[],
+            }),
+        ],
     }),
     GeneratorOptionItem::Category(GeneratorOptionCategory {
         name: "optional",

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ static OPTIONS: &[GeneratorOptionItem] = &[
     }),
     GeneratorOptionItem::Category(GeneratorOptionCategory {
         name: "panic",
-        display_name: "Panic handling options",
+        display_name: "Panic handler options",
         options: &[GeneratorOptionItem::Option(GeneratorOption {
             name: "panic-esp-backtrace",
             display_name: "Use `esp-backtrace`.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,22 +186,13 @@ static OPTIONS: &[GeneratorOptionItem] = &[
     GeneratorOptionItem::Category(GeneratorOptionCategory {
         name: "panic",
         display_name: "Panic handling options",
-        options: &[
-            GeneratorOptionItem::Option(GeneratorOption {
-                name: "panic-esp-backtrace",
-                display_name: "Use `esp-backtrace`.",
-                enables: &[],
-                disables: &["panic-panic-probe"],
-                chips: &[],
-            }),
-            GeneratorOptionItem::Option(GeneratorOption {
-                name: "panic-panic-probe",
-                display_name: "Use `panic-probe`. Requires `probe-rs`.",
-                enables: &["probe-rs"],
-                disables: &["panic-esp-backtrace"],
-                chips: &[],
-            }),
-        ],
+        options: &[GeneratorOptionItem::Option(GeneratorOption {
+            name: "panic-esp-backtrace",
+            display_name: "Use `esp-backtrace`.",
+            enables: &[],
+            disables: &[],
+            chips: &[],
+        })],
     }),
     GeneratorOptionItem::Category(GeneratorOptionCategory {
         name: "optional",
@@ -548,6 +539,15 @@ fn process_file(
             };
             let res = engine.eval::<bool>(cond).unwrap();
             include.push(res && *include.last().unwrap());
+        } else if trimmed.starts_with("#ELIF ") || trimmed.starts_with("//ELIF ") {
+            let cond = if trimmed.starts_with("#ELIF ") {
+                trimmed.strip_prefix("#ELIF ").unwrap()
+            } else {
+                trimmed.strip_prefix("//ELIF ").unwrap()
+            };
+            let res = engine.eval::<bool>(cond).unwrap();
+            let last = include.pop();
+            include.push(res && !last.unwrap());
         } else if trimmed.starts_with("#ELSE") || trimmed.starts_with("//ELSE") {
             let res = !*include.last().unwrap();
             include.pop();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -75,8 +75,15 @@ impl Repository {
                         panic!("option not found");
                     };
                     for enable in option.enables {
-                        if !self.selected.contains(&enable.to_string()) {
-                            self.selected.push(enable.to_string());
+                        let mut contains_any = false;
+                        for enable_option in enable.iter() {
+                            if self.selected.contains(&enable_option.to_string()) {
+                                contains_any = true;
+                                break;
+                            }
+                        }
+                        if !contains_any && !enable.is_empty() {
+                            self.selected.push(enable[0].to_string());
                         }
                     }
                     for disable in option.disables {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -327,8 +327,8 @@ impl App {
             .repository
             .current_level_desc()
             .into_iter()
-            .map(|v| {
-                ListItem::new(v.1).style(if v.0 {
+            .map(|(enabled, value)| {
+                ListItem::new(value).style(if enabled {
                     Style::default()
                 } else {
                     Style::default().fg(DISABLED_STYLE_FG)

--- a/template/.cargo/config.toml
+++ b/template/.cargo/config.toml
@@ -3,12 +3,10 @@
 #IF option("probe-rs")
 #REPLACE esp32c6 mcu
 runner = "probe-rs run --chip=esp32c6 --always-print-stacktrace --no-location --catch-hardfault"
-#ENDIF
-#IF !option("probe-rs") && option("log-frontend-defmt")
+#ELIF option("log-frontend-defmt")
 #REPLACE esp32c6 mcu
-#+runner = "espflash flash --monitor --chip esp32c6" --log-format=defmt
-#ENDIF
-#IF !option("probe-rs") && !option("log-frontend-defmt")
+#+runner = "espflash flash --monitor --chip esp32c6 --log-format=defmt"
+#ELSE
 #REPLACE esp32c6 mcu
 #+runner = "espflash flash --monitor --chip esp32c6"
 #ENDIF
@@ -16,8 +14,7 @@ runner = "probe-rs run --chip=esp32c6 --always-print-stacktrace --no-location --
 [env]
 #IF option("log-frontend-defmt")
 DEFMT_LOG="info"
-#ENDIF
-#IF option("log-frontend-log")
+#ELIF option("log-frontend-log")
 ESP_LOG="INFO"
 #ENDIF
 
@@ -25,8 +22,7 @@ ESP_LOG="INFO"
 rustflags = [
 #IF option("xtensa")
   "-C", "link-arg=-nostartfiles",
-#ENDIF
-#IF option("riscv")
+#ELIF option("riscv")
   # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
   # NOTE: May negatively impact performance of produced code
   "-C", "force-frame-pointers",

--- a/template/.cargo/config.toml
+++ b/template/.cargo/config.toml
@@ -3,15 +3,21 @@
 #IF option("probe-rs")
 #REPLACE esp32c6 mcu
 runner = "probe-rs run --chip=esp32c6 --always-print-stacktrace --no-location --catch-hardfault"
-#ELSE
+#ENDIF
+#IF !option("probe-rs") && option("log-frontend-defmt")
+#REPLACE esp32c6 mcu
+#+runner = "espflash flash --monitor --chip esp32c6" --log-format=defmt
+#ENDIF
+#IF !option("probe-rs") && !option("log-frontend-defmt")
 #REPLACE esp32c6 mcu
 #+runner = "espflash flash --monitor --chip esp32c6"
 #ENDIF
 
 [env]
-#IF option("probe-rs")
+#IF option("log-frontend-defmt")
 DEFMT_LOG="info"
-#ELSE
+#ENDIF
+#IF option("log-frontend-log")
 ESP_LOG="INFO"
 #ENDIF
 

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -10,29 +10,37 @@ name = "project-name"
 path = "./src/bin/main.rs"
 
 [dependencies]
+#IF option("panic-esp-backtrace")
 esp-backtrace = { version = "0.15.0", features = [
     #REPLACE esp32c6 mcu
     "esp32c6",
     "exception-handler",
     "panic-handler",
-    #IF option("probe-rs")
+    #IF option("log-frontend-defmt")
     #+"defmt",
     #ELSE
     "println",
     #ENDIF
 ]}
+#ENDIF
 esp-hal = { version = "0.23.1", features = [
     #REPLACE esp32c6 mcu
     "esp32c6",
     "unstable",
-    #IF option("probe-rs")
+    #IF option("log-frontend-defmt")
     #+"defmt",
     #ENDIF
 ] }
-#IF !option("probe-rs")
+#IF option("log-backend-esp-println")
 #REPLACE esp32c6 mcu
 esp-println = { version = "0.13.0", features = ["esp32c6", "log"] }
+#ELIF option("log-backend-defmt-rtt")
+#+defmt-rtt        = "0.4.1"
+#ENDIF
+#IF option("log-frontend-log")
 log = { version = "0.4.21" }
+#ELIF option("log-frontend-defmt")
+#+defmt            = "0.3.10"
 #ENDIF
 #IF option("alloc")
 esp-alloc = { version = "0.6.0" }
@@ -59,10 +67,9 @@ esp-wifi = { version = "0.12.0", default-features=false, features = [
     "coex",
     #ENDIF
     "esp-alloc",
-    #IF option("probe-rs")
+    #IF option("log-frontend-defmt")
     #+"defmt",
-    #ENDIF
-    #IF !option("probe-rs")
+    #ELIF option("log-frontend-log")
     "log",
     #ENDIF
 ] }
@@ -86,14 +93,10 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
 #IF option("ble")
 #+bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "a5148d8ae679e021b78f53fd33afb8bb35d0b62e", features = [ "macros", "async"] }
 #ENDIF
-#IF option("probe-rs")
-#+defmt            = "0.3.10"
-#+defmt-rtt        = "0.4.1"
-#ENDIF
 #IF option("embassy")
 embassy-executor = { version = "0.7.0",  features = [
     "task-arena-size-20480",
-    #IF option("probe-rs")
+    #IF option("log-frontend-defmt")
     "defmt"
     #ENDIF
 ] }

--- a/template/build.rs
+++ b/template/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     linker_be_nice();
-    //IF option("probe-rs")
+    //IF option("log-frontend-defmt")
     println!("cargo:rustc-link-arg=-Tdefmt.x");
     //ENDIF
     // make sure linkall.x is the last linker script (otherwise might cause problems with flip-link)

--- a/template/rust-toolchain.toml
+++ b/template/rust-toolchain.toml
@@ -4,7 +4,6 @@ channel    = "stable"
 components = ["rust-src"]
 #REPLACE riscv32imac-unknown-none-elf rust_target
 targets = ["riscv32imac-unknown-none-elf"]
-#ENDIF
-#IF option("xtensa")
+#ELIF option("xtensa")
 #+channel = "esp"
 #ENDIF

--- a/template/src/bin/async_main.rs
+++ b/template/src/bin/async_main.rs
@@ -6,24 +6,21 @@ use esp_hal::clock::CpuClock;
 
 //IF option("panic-esp-backtrace")
 use esp_backtrace as _;
-//ENDIF
-//IF option("panic-panic-probe")
-//+ use panic_probe as _;
-//ENDIF
-//IF !option("panic-esp-backtrace") && !option("panic-panic-probe")
-//+ #[panic_handler]
-//+ fn panic(_: &core::panic::PanicInfo) -> ! {
-//+     esp_hal::system::software_reset()
-//+ }
+//ELSE
+//+#[panic_handler]
+//+fn panic(_: &core::panic::PanicInfo) -> ! {
+//+    esp_hal::system::software_reset()
+//+}
 //ENDIF
 
 //IF option("log-backend-defmt-rtt")
-//+ use defmt_rtt as _;
+//+use defmt_rtt as _;
+//ELIF option("log-backend-esp-println") && (option("log-frontend-log") || option("log-frontend-defmt"))
+//+use esp_println as _;
 //ENDIF
 //IF option("log-frontend-defmt")
-//+ use defmt::info;
-//ENDIF
-//IF option("log-frontend-log")
+//+use defmt::info;
+//ELIF option("log-frontend-log")
 use log::info;
 //ENDIF
 
@@ -60,8 +57,7 @@ async fn main(spawner: Spawner) {
 
     //IF option("log-frontend-defmt") || option("log-frontend-log")
     info!("Embassy initialized!");
-    //ENDIF
-    //IF option("log-backend-esp-println") && !option("log-frontend-defmt") && !option("log-frontend-log")
+    //ELIF option("log-backend-esp-println")
     //+esp_println::println!("Embassy initialized!");
     //ENDIF
 
@@ -81,8 +77,7 @@ async fn main(spawner: Spawner) {
     loop {
         //IF option("log-frontend-defmt") || option("log-frontend-log")
         info!("Hello world!");
-        //ENDIF
-        //IF option("log-backend-esp-println") && !option("log-frontend-defmt") && !option("log-frontend-log")
+        //ELIF option("log-backend-esp-println")
         //+esp_println::println!("Hello world!");
         //ENDIF
         Timer::after(Duration::from_secs(1)).await;

--- a/template/src/bin/main.rs
+++ b/template/src/bin/main.rs
@@ -2,16 +2,35 @@
 #![no_std]
 #![no_main]
 
-use esp_backtrace as _;
-use esp_hal::{clock::CpuClock, delay::Delay, main};
+use esp_hal::{
+    clock::CpuClock,
+    main,
+    time::{Duration, Instant},
+};
 //IF option("wifi") || option("ble")
 use esp_hal::timer::timg::TimerGroup;
 //ENDIF
 
-//IF option("probe-rs")
+//IF option("panic-esp-backtrace")
+use esp_backtrace as _;
+//ENDIF
+//IF option("panic-panic-probe")
+//+ use panic_probe as _;
+//ENDIF
+//IF !option("panic-esp-backtrace") && !option("panic-panic-probe")
+//+ #[panic_handler]
+//+ fn panic(_: &core::panic::PanicInfo) -> ! {
+//+     esp_hal::system::software_reset()
+//+ }
+//ENDIF
+
+//IF option("log-backend-defmt-rtt")
 //+ use defmt_rtt as _;
+//ENDIF
+//IF option("log-frontend-defmt")
 //+ use defmt::info;
-//ELSE
+//ENDIF
+//IF option("log-frontend-log")
 use log::info;
 //ENDIF
 
@@ -24,15 +43,15 @@ fn main() -> ! {
     //REPLACE generate-version generate-version
     // generator version: generate-version
 
+    //IF option("log-frontend-log")
+    esp_println::logger::init_logger_from_env();
+    //ENDIF
+
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     //IF option("wifi") || option("ble")
     let peripherals = esp_hal::init(config);
     //ELSE
     //+let _peripherals = esp_hal::init(config);
-    //ENDIF
-
-    //IF !option("probe-rs")
-    esp_println::logger::init_logger_from_env();
     //ENDIF
 
     //IF option("alloc")
@@ -51,8 +70,14 @@ fn main() -> ! {
 
     let delay = Delay::new();
     loop {
+        //IF option("log-frontend-defmt") || option("log-frontend-log")
         info!("Hello world!");
-        delay.delay_millis(500);
+        //ENDIF
+        //IF option("log-backend-esp-println") && !option("log-frontend-defmt") && !option("log-frontend-log")
+        //+esp_println::println!("Hello world!");
+        //ENDIF
+        let delay_start = Instant::now();
+        while delay_start.elapsed() < Duration::from_millis(500) {}
     }
 
     // for inspiration have a look at the examples at https://github.com/esp-rs/esp-hal/tree/v0.23.1/examples/src/bin

--- a/template/src/bin/main.rs
+++ b/template/src/bin/main.rs
@@ -13,24 +13,21 @@ use esp_hal::timer::timg::TimerGroup;
 
 //IF option("panic-esp-backtrace")
 use esp_backtrace as _;
-//ENDIF
-//IF option("panic-panic-probe")
-//+ use panic_probe as _;
-//ENDIF
-//IF !option("panic-esp-backtrace") && !option("panic-panic-probe")
-//+ #[panic_handler]
-//+ fn panic(_: &core::panic::PanicInfo) -> ! {
-//+     esp_hal::system::software_reset()
-//+ }
+//ELSE
+//+#[panic_handler]
+//+fn panic(_: &core::panic::PanicInfo) -> ! {
+//+    esp_hal::system::software_reset()
+//+}
 //ENDIF
 
 //IF option("log-backend-defmt-rtt")
-//+ use defmt_rtt as _;
+//+use defmt_rtt as _;
+//ELIF option("log-backend-esp-println") && (option("log-frontend-log") || option("log-frontend-defmt"))
+//+use esp_println as _;
 //ENDIF
 //IF option("log-frontend-defmt")
-//+ use defmt::info;
-//ENDIF
-//IF option("log-frontend-log")
+//+use defmt::info;
+//ELIF option("log-frontend-log")
 use log::info;
 //ENDIF
 
@@ -72,10 +69,10 @@ fn main() -> ! {
     loop {
         //IF option("log-frontend-defmt") || option("log-frontend-log")
         info!("Hello world!");
-        //ENDIF
-        //IF option("log-backend-esp-println") && !option("log-frontend-defmt") && !option("log-frontend-log")
+        //ELIF option("log-backend-esp-println")
         //+esp_println::println!("Hello world!");
         //ENDIF
+
         let delay_start = Instant::now();
         while delay_start.elapsed() < Duration::from_millis(500) {}
     }


### PR DESCRIPTION
This PR adds support for more rtt backends, panic handlers, etc, hoping to be able to use `rtt-target` eventually. The PR also adds support for `#ELIF`, and "enable alternatives" so that a feature can depend on "one of a list".