### PR TITLE
Support `ELIF` (else-if) in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Added a version checker that prints a warn message if not using latest esp-generate version (#87)
 - After generating the project the tool now checks the rust version, espflash version and probe-rs version (#88)
-
 - Be more helpful in case of common linker errors (#94)
+- Support for `ELIF` conditions (#96)
 
 ### Changed
 - Update `probe-rs run` arguments (#90)

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -327,8 +327,8 @@ impl App {
             .repository
             .current_level_desc()
             .into_iter()
-            .map(|v| {
-                ListItem::new(v.1).style(if v.0 {
+            .map(|(enabled, value)| {
+                ListItem::new(value).style(if enabled {
                     Style::default()
                 } else {
                     Style::default().fg(DISABLED_STYLE_FG)

--- a/template/.cargo/config.toml
+++ b/template/.cargo/config.toml
@@ -19,8 +19,7 @@ ESP_LOG="INFO"
 rustflags = [
 #IF option("xtensa")
   "-C", "link-arg=-nostartfiles",
-#ENDIF
-#IF option("riscv")
+#ELIF option("riscv")
   # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
   # NOTE: May negatively impact performance of produced code
   "-C", "force-frame-pointers",

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -33,6 +33,9 @@ esp-hal = { version = "0.23.1", features = [
 #REPLACE esp32c6 mcu
 esp-println = { version = "0.13.0", features = ["esp32c6", "log"] }
 log = { version = "0.4.21" }
+#ELSE
+#+defmt            = "0.3.10"
+#+defmt-rtt        = "0.4.1"
 #ENDIF
 #IF option("alloc")
 esp-alloc = { version = "0.6.0" }
@@ -61,8 +64,7 @@ esp-wifi = { version = "0.12.0", default-features=false, features = [
     "esp-alloc",
     #IF option("probe-rs")
     #+"defmt",
-    #ENDIF
-    #IF !option("probe-rs")
+    #ELSE
     "log",
     #ENDIF
 ] }
@@ -86,15 +88,11 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
 #IF option("ble")
 #+bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "a5148d8ae679e021b78f53fd33afb8bb35d0b62e", features = [ "macros", "async"] }
 #ENDIF
-#IF option("probe-rs")
-#+defmt            = "0.3.10"
-#+defmt-rtt        = "0.4.1"
-#ENDIF
 #IF option("embassy")
 embassy-executor = { version = "0.7.0",  features = [
     "task-arena-size-20480",
     #IF option("probe-rs")
-    "defmt"
+    #+"defmt"
     #ENDIF
 ] }
 embassy-time     = { version = "0.4.0",  features = ["generic-queue-8"] }

--- a/template/rust-toolchain.toml
+++ b/template/rust-toolchain.toml
@@ -4,7 +4,6 @@ channel    = "stable"
 components = ["rust-src"]
 #REPLACE riscv32imac-unknown-none-elf rust_target
 targets = ["riscv32imac-unknown-none-elf"]
-#ENDIF
-#IF option("xtensa")
+#ELIF option("xtensa")
 #+channel = "esp"
 #ENDIF

--- a/template/src/bin/async_main.rs
+++ b/template/src/bin/async_main.rs
@@ -7,8 +7,7 @@ use esp_hal::clock::CpuClock;
 //IF option("probe-rs")
 //+ use defmt_rtt as _;
 //+ use defmt::info;
-//ENDIF
-//IF !option("probe-rs")
+//ELSE
 use log::info;
 //ENDIF
 
@@ -24,15 +23,15 @@ async fn main(spawner: Spawner) {
     //REPLACE generate-version generate-version
     // generator version: generate-version
 
+    //IF !option("probe-rs")
+    esp_println::logger::init_logger_from_env();
+    //ENDIF
+
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
     //IF option("alloc")
     esp_alloc::heap_allocator!(72 * 1024);
-    //ENDIF
-
-    //IF !option("probe-rs")
-    esp_println::logger::init_logger_from_env();
     //ENDIF
 
     //IF !option("esp32")

--- a/template/src/bin/main.rs
+++ b/template/src/bin/main.rs
@@ -24,15 +24,15 @@ fn main() -> ! {
     //REPLACE generate-version generate-version
     // generator version: generate-version
 
+    //IF !option("probe-rs")
+    esp_println::logger::init_logger_from_env();
+    //ENDIF
+
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     //IF option("wifi") || option("ble")
     let peripherals = esp_hal::init(config);
     //ELSE
     //+let _peripherals = esp_hal::init(config);
-    //ENDIF
-
-    //IF !option("probe-rs")
-    esp_println::logger::init_logger_from_env();
     //ENDIF
 
     //IF option("alloc")


### PR DESCRIPTION
This PR adds support for else-if in templates, which will be useful if we are going to have more options that are mutually exclusive.

The PR also reorders log setup to before HAL initialization, so that the HAL's init process may be able to print logs if such configured.