### PR TITLE
Replace automatic option enable/disable with a list of requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When using `embassy` option, `async_main.rs` file was renamed to `main.rs` (#93)
 - The UI no longer allows selecting options with missing requirements, and does not allow deselecting
   options that are required by other options. (#101)
+- Options can now declare negative requirements (e.g. `!alloc` can not be enabled if `alloc` is used) (#101)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `probe-rs run` arguments (#90)
 - When using `embassy` option, `async_main.rs` file was renamed to `main.rs` (#93)
+- The UI no longer allows selecting options with missing requirements, and does not allow deselecting
+  options that are required by other options. (#101)
 
 ### Fixed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,7 @@ pub struct GeneratorOption {
     name: &'static str,
     display_name: &'static str,
     help: &'static str,
-    enables: &'static [&'static str],
-    disables: &'static [&'static str],
+    requires: &'static [&'static str],
     chips: &'static [Chip],
 }
 
@@ -90,10 +89,10 @@ impl GeneratorOptionItem {
         }
     }
 
-    fn enables(&self) -> &[&str] {
+    fn requires(&self) -> &[&str] {
         match self {
             GeneratorOptionItem::Category(_) => &[],
-            GeneratorOptionItem::Option(option) => option.enables,
+            GeneratorOptionItem::Option(option) => option.requires,
         }
     }
 
@@ -110,16 +109,14 @@ static OPTIONS: &[GeneratorOptionItem] = &[
         name: "alloc",
         display_name: "Enable allocations via the `esp-alloc` crate.",
         help: "",
-        enables: &[],
-        disables: &[],
+        requires: &[],
         chips: &[],
     }),
     GeneratorOptionItem::Option(GeneratorOption {
         name: "wifi",
         display_name: "Enable Wi-Fi via the `esp-wifi` crate.",
         help: "Requires `alloc`. Not available on ESP32-H2.",
-        enables: &["alloc"],
-        disables: &[],
+        requires: &["alloc"],
         chips: &[
             Chip::Esp32,
             Chip::Esp32c2,
@@ -133,8 +130,7 @@ static OPTIONS: &[GeneratorOptionItem] = &[
         name: "ble",
         display_name: "Enable BLE via the `esp-wifi` crate.",
         help: "Requires `alloc`. Not available on ESP32-S2.",
-        enables: &["alloc"],
-        disables: &[],
+        requires: &["alloc"],
         chips: &[
             Chip::Esp32,
             Chip::Esp32c2,
@@ -148,16 +144,14 @@ static OPTIONS: &[GeneratorOptionItem] = &[
         name: "embassy",
         display_name: "Add `embassy` framework support.",
         help: "",
-        enables: &[],
-        disables: &[],
+        requires: &[],
         chips: &[],
     }),
     GeneratorOptionItem::Option(GeneratorOption {
         name: "probe-rs",
         display_name: "Enable `defmt` and flashes using `probe-rs` instead of `espflash`.",
         help: "",
-        enables: &[],
-        disables: &[],
+        requires: &[],
         chips: &[],
     }),
     GeneratorOptionItem::Category(GeneratorOptionCategory {
@@ -169,8 +163,7 @@ static OPTIONS: &[GeneratorOptionItem] = &[
                 name: "wokwi",
                 display_name: "Add support for Wokwi simulation using VS Code Wokwi extension.",
                 help: "",
-                enables: &[],
-                disables: &[],
+                requires: &[],
                 chips: &[
                     Chip::Esp32,
                     Chip::Esp32c3,
@@ -184,16 +177,14 @@ static OPTIONS: &[GeneratorOptionItem] = &[
                 name: "dev-container",
                 display_name: "Add support for VS Code Dev Containers and GitHub Codespaces.",
                 help: "",
-                enables: &[],
-                disables: &[],
+                requires: &[],
                 chips: &[],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
                 name: "ci",
                 display_name: "Add GitHub Actions support with some basic checks.",
                 help: "",
-                enables: &[],
-                disables: &[],
+                requires: &[],
                 chips: &[],
             }),
         ],
@@ -207,16 +198,14 @@ static OPTIONS: &[GeneratorOptionItem] = &[
                 name: "helix",
                 display_name: "Add rust-analyzer settings for Helix Editor",
                 help: "",
-                enables: &[],
-                disables: &[],
+                requires: &[],
                 chips: &[],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
                 name: "vscode",
                 display_name: "Add rust-analyzer settings for Visual Studio Code",
                 help: "",
-                enables: &[],
-                disables: &[],
+                requires: &[],
                 chips: &[],
             }),
         ],
@@ -626,14 +615,14 @@ fn process_options(args: &Args) {
                 process::exit(-1);
             }
             if !option_item
-                .enables()
+                .requires()
                 .iter()
-                .all(|requirement| args.option.contains(&requirement.to_string()))
+                .all(|requirement| args.option.iter().any(|r| r == requirement))
             {
                 log::error!(
                     "Option '{}' requires {}",
                     option_item.name(),
-                    option_item.enables().join(", ")
+                    option_item.requires().join(", ")
                 );
                 process::exit(-1);
             }


### PR DESCRIPTION
This may be somewhat of a UX regression, as we no longer enable/disable options automatically, but instead dynamically change whether an item is active or not. We could still reintroduce the automatic requirement selection (which I think may be slightly confusing), but that is a tricky problem to solve now, especially if options get into a requires-requires not cycle.

I'm slightly worried about the regression, because now if we have exclusive options, those don't deselect each other, but the user has to manually toggle them. This also means that the "neither one selected" must be a valid option, although even the previous method didn't handle "option A enables option B enables option C" recursive cases so maybe this is just trading limitations.

The goal of this PR is to enable "Allow unstable HAL features" and "Allow unstable dependencies" options.

After this, we could probably perma-hide features that are not available on the current chip. Having an option suggests it can be enabled somehow.