### PR TITLE
Deduplicate redundant "All options"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --manifest-path xtask/Cargo.toml --"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,5 @@
 name: CI
 on:
-  push:
-    branches-ignore:
-      - "gh-readonly-queue/**"
-    paths-ignore:
-      - "**/README.md"
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -142,15 +142,14 @@ fn options_for_chip(chip: Chip, all_combinations: bool) -> Vec<Vec<String>> {
                     options.extend(available_options[j].clone());
                 }
             }
+            options.sort();
+            options.dedup();
             result.push(options);
         }
-        // Filter all the items that contains wifi and ble
-        let result = result
-            .into_iter()
-            .filter(|opts| {
-                !opts.contains(&"wifi".to_string()) || !opts.contains(&"ble".to_string())
-            })
-            .collect::<Vec<_>>();
+
+        result.sort();
+        result.dedup();
+
         return result;
     }
 }


### PR DESCRIPTION
Before this PR we were testing the same combination several times.

```
[2025-02-10T15:17:48Z INFO  xtask] ["alloc", "probe-rs"]
[2025-02-10T15:17:48Z INFO  xtask] ["alloc", "probe-rs"]
[2025-02-10T15:17:48Z INFO  xtask] ["alloc", "probe-rs", "wifi"]
[2025-02-10T15:17:48Z INFO  xtask] ["alloc", "probe-rs", "wifi"]
[2025-02-10T15:17:48Z INFO  xtask] ["alloc", "alloc", "probe-rs", "wifi"]
[2025-02-10T15:17:48Z INFO  xtask] ["alloc", "alloc", "probe-rs", "wifi"]
```

This PR hopefully cuts down the CI time a bit. We also seem to support `wifi && ble` at least in some places in the templates, so I've removed the filter for them.

The PR also removes the `push` trigger because for some reason, everything ran twice on each PR.