### PR TITLE
Run generate in debug mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,11 @@ jobs:
 
       - name: Generate and check project
         if: github.event_name != 'schedule' &&  !inputs.all_combinations
-        run: cd xtask && cargo ${{ env.TOOLCHAIN }} run -- check ${{ matrix.chip }}
+        run: cargo ${{ env.TOOLCHAIN }} xtask check ${{ matrix.chip }}
 
       - name: Generate and check project (all combinations)
         if: github.event_name == 'schedule' ||  inputs.all_combinations
-        run: cd xtask && cargo ${{ env.TOOLCHAIN }} run -- check ${{ matrix.chip }} --all-combinations
+        run: cargo ${{ env.TOOLCHAIN }} xtask check ${{ matrix.chip }} --all-combinations
 
   # --------------------------------------------------------------------------
   # Test

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -231,7 +231,7 @@ fn generate(
 ) -> Result<()> {
     let mut args = vec![
         "run",
-        "--release",
+        "--no-default-features",
         "--",
         "--headless",
         &format!("--chip={chip}"),


### PR DESCRIPTION
`esp-generate` fails to compile for some reason on Windows, when ran by the xtask from another directory. I don't really know why, and why this happens with `--release`, but removing that seems to work just fine. `--no-default-features` disables the update checker, which is unnecessary for local/CI testing.