### PR TITLE
Use separate inactive highlight colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Template settings are now described in a template-specific `yaml` file (#103)
 - Test cases are now generated from template settings (#106)
 - Updated and removed some unused extensions (#109, #111)
+- Inactive menu items are now colored differently (#115)
 
 ### Fixed
 


### PR DESCRIPTION
Adds the ability to select separate colors for active/inactive items, and implements https://github.com/esp-rs/esp-generate/pull/113#issuecomment-2655993230

I did tweak the inactive colors a bit compared to #113 so that they are a bit more readable.

Active item:

![image](https://github.com/user-attachments/assets/cd5172b6-21e7-48e1-b379-ffac5b1e8399)

Inactive item:
![image](https://github.com/user-attachments/assets/19c75aec-da8b-4f24-a9db-aba7d76ea806)
