### PR TITLE
Display names of options, completely remove chip-incompatible settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Template settings are now described in a template-specific `yaml` file (#103)
 - Test cases are now generated from template settings (#106)
 - Updated and removed some unused extensions (#109, #111)
+- The option names are now display in the menu (#116)
+- Options that are not applicable to the selected chip are not shown (#116)
 
 ### Fixed
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -22,13 +22,13 @@ const TEXT_COLOR: Color = tailwind::SLATE.c200;
 
 type AppResult<T> = Result<T, Box<dyn Error>>;
 
-pub struct Repository {
-    config: ActiveConfiguration<'static>,
+pub struct Repository<'app> {
+    config: ActiveConfiguration<'app>,
     path: Vec<usize>,
 }
 
-impl Repository {
-    pub fn new(chip: Chip, options: &'static [GeneratorOptionItem], selected: &[String]) -> Self {
+impl<'app> Repository<'app> {
+    pub fn new(chip: Chip, options: &'app [GeneratorOptionItem], selected: &[String]) -> Self {
         Self {
             config: ActiveConfiguration {
                 chip,
@@ -131,14 +131,14 @@ pub fn restore_terminal() -> AppResult<()> {
     Ok(())
 }
 
-pub struct App {
+pub struct App<'app> {
     state: Vec<ListState>,
-    repository: Repository,
+    repository: Repository<'app>,
     confirm_quit: bool,
 }
 
-impl App {
-    pub fn new(repository: Repository) -> Self {
+impl<'app> App<'app> {
+    pub fn new(repository: Repository<'app>) -> Self {
         let mut initial_state = ListState::default();
         initial_state.select(Some(0));
 
@@ -178,7 +178,7 @@ impl App {
     }
 }
 
-impl App {
+impl App<'_> {
     pub fn run(&mut self, mut terminal: Terminal<impl Backend>) -> AppResult<Option<Vec<String>>> {
         loop {
             self.draw(&mut terminal)?;
@@ -243,7 +243,7 @@ impl App {
     }
 }
 
-impl Widget for &mut App {
+impl Widget for &mut App<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let vertical = Layout::vertical([
             Constraint::Length(2),
@@ -260,7 +260,7 @@ impl Widget for &mut App {
     }
 }
 
-impl App {
+impl App<'_> {
     fn render_title(&self, area: Rect, buf: &mut Buffer) {
         Paragraph::new("esp-generate")
             .bold()

--- a/template/template.yaml
+++ b/template/template.yaml
@@ -12,7 +12,6 @@ options:
   - !Option
     name: wifi
     display_name: Enable Wi-Fi via the `esp-wifi` crate.
-    help: Not available on ESP32-H2.
     requires:
       - alloc
       - unstable-hal
@@ -27,7 +26,6 @@ options:
   - !Option
     name: ble
     display_name: Enable BLE via the `esp-wifi` crate.
-    help: Not available on ESP32-S2.
     requires:
       - alloc
       - unstable-hal


### PR DESCRIPTION
The result of this PR is this screenshot for the S2 (note the lack of BLE option):

![image](https://github.com/user-attachments/assets/472778ee-dfa5-48b1-b49f-7851fd8c43f9)

Hopefully this isn't too visually busy. We refer to the option names in multiple places, so we might as well show their names.