### PR TITLE
Embassy needs unstable hal

### DIFF
--- a/template/template.yaml
+++ b/template/template.yaml
@@ -39,7 +39,10 @@ options:
 
   - !Option
     name: embassy
-    display_name: Add `embassy` framework support.
+    display_name: Add embassy framework support.
+    help: esp-hal-embassy comes with no stability guarantees at this time.
+    requires:
+      - unstable-hal
 
   - !Option
     name: probe-rs


### PR DESCRIPTION
`esp-hal-embassy` relies on timers and so it needs to be gated behind `unstable-hal`