### PR TITLE
Implement selection groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `ELIF` conditions (#96)
 - Display help text (#100, #103)
 - Added an option to enable unstable HAL features (#104)
+- Added support for selection groups (#119)
 
 ### Changed
 - Update `probe-rs run` arguments (#90)

--- a/src/template.rs
+++ b/src/template.rs
@@ -29,6 +29,8 @@ pub struct GeneratorOptionCategory {
     #[serde(default)]
     pub help: String,
     #[serde(default)]
+    pub requires: Vec<String>,
+    #[serde(default)]
     pub options: Vec<GeneratorOptionItem>,
 }
 
@@ -83,7 +85,7 @@ impl GeneratorOptionItem {
 
     pub fn requires(&self) -> &[String] {
         match self {
-            GeneratorOptionItem::Category(_) => &[],
+            GeneratorOptionItem::Category(category) => category.requires.as_slice(),
             GeneratorOptionItem::Option(option) => option.requires.as_slice(),
         }
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 pub struct GeneratorOption {
     pub name: String,
     pub display_name: String,
+    /// Selecting one option in the group deselect other options of the same group.
+    #[serde(default)]
+    pub selection_group: String,
     #[serde(default)]
     pub help: String,
     #[serde(default)]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -83,7 +83,7 @@ impl<'app> Repository<'app> {
             if self.config.can_be_disabled(&option.name) {
                 self.config.selected.swap_remove(i);
             }
-        } else if self.config.requirements_met(option) {
+        } else {
             self.config.select(option.name.clone());
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -146,7 +146,7 @@ fn enable_config_and_dependencies(config: &mut ActiveConfiguration, option: &str
         enable_config_and_dependencies(config, dependency)?;
     }
 
-    if !config.requirements_met(option) {
+    if !config.is_option_active(option) {
         return Ok(());
     }
 
@@ -158,7 +158,7 @@ fn enable_config_and_dependencies(config: &mut ActiveConfiguration, option: &str
 fn is_valid(config: &ActiveConfiguration) -> bool {
     for item in config.selected.iter() {
         let option = find_option(item, &config.options).unwrap();
-        if !config.requirements_met(option) {
+        if !config.is_option_active(option) {
             return false;
         }
     }


### PR DESCRIPTION
Selection groups behave similar to radio groups in the web: only one option in a group may be selected. They are meant to allow selecting exclusive features (such as log vs defmt), and also allow requiring "one-of-N" options (i.e. defmt requires esp-println, defmt-rtt or rtt-target).

This was pretty hard to get right, evaluating the requirements turned out a bit more complicated than I wanted.