### PR TITLE
Allow building test projects, build during scheduled checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     - cron: "34 2 * * *"
   workflow_dispatch:
     inputs:
+      build:
+        description: "Fully build the tested configurations"
+        required: true
+        type: boolean
       all_combinations:
         description: "Checks all combinations of options"
         required: true
@@ -67,12 +71,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Generate and check project
-        if: github.event_name != 'schedule' &&  !inputs.all_combinations
-        run: cargo ${{ env.TOOLCHAIN }} xtask check ${{ matrix.chip }}
-
-      - name: Generate and check project (all combinations)
-        if: github.event_name == 'schedule' ||  inputs.all_combinations
-        run: cargo ${{ env.TOOLCHAIN }} xtask check ${{ matrix.chip }} --all-combinations
+        run: cargo ${{ env.TOOLCHAIN }} xtask check ${{ matrix.chip }} ${{ fromJSON('["", "--all-combinations"]')[inputs.all_combinations || github.event_name == 'schedule'] }} ${{ fromJSON('["", "--build"]')[inputs.build || github.event_name == 'schedule'] }}
 
   # --------------------------------------------------------------------------
   # Test

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -28,6 +28,9 @@ enum Commands {
         /// Verify all possible options combinations
         #[arg(short, long)]
         all_combinations: bool,
+        /// Actually build projects, instead of just checking them
+        #[arg(short, long)]
+        build: bool,
     },
 
     /// Prints all valid combinations of options for a given chip
@@ -55,7 +58,8 @@ fn main() -> Result<()> {
         Commands::Check {
             chip,
             all_combinations,
-        } => check(&workspace, chip, all_combinations),
+            build,
+        } => check(&workspace, chip, all_combinations, build),
 
         Commands::Options {
             chip,
@@ -72,8 +76,12 @@ fn main() -> Result<()> {
 // ----------------------------------------------------------------------------
 // CHECK
 
-fn check(workspace: &Path, chip: Chip, all_combinations: bool) -> Result<()> {
-    log::info!("CHECK: {chip}");
+fn check(workspace: &Path, chip: Chip, all_combinations: bool, build: bool) -> Result<()> {
+    if build {
+        log::info!("BUILD: {chip}");
+    } else {
+        log::info!("CHECK: {chip}");
+    }
 
     const PROJECT_NAME: &str = "test";
     for options in options_for_chip(chip, all_combinations)? {
@@ -91,7 +99,7 @@ fn check(workspace: &Path, chip: Chip, all_combinations: bool) -> Result<()> {
 
         // Ensure that the generated project builds without errors:
         let output = Command::new("cargo")
-            .args(["check"])
+            .args([if build { "build" } else { "check" }])
             .current_dir(project_path.join(PROJECT_NAME))
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())


### PR DESCRIPTION
I've messed up a few things that only fail during linking, so let's have the ability to build configs if we want to - and also during the night.