### PR TITLE
fix: prevent ci jobs from running twice on pull requests

### DIFF
--- a/template/.github/workflows/rust_ci.yml
+++ b/template/.github/workflows/rust_ci.yml
@@ -3,6 +3,8 @@ name: Continuous Integration
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - "**/README.md"
   pull_request:


### PR DESCRIPTION
Currently CI jobs run both on `pull_request` and `push`, which causes them to run twice on each push to a PR. I restricted `on.push.branches` to `main` to prevent that.