### PR TITLE
Fix embedded-io features to use defmt-03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The generated project no longer contains `template.yaml`. (#142)
 - Fixed parsing version output of old `espflash`. (#152)
+- Specified `defmt-03` feature for `embedded-io` and `embedded-io-async`. (#157)
 
 ### Removed
 

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -86,13 +86,13 @@ esp-alloc = "0.7.0"
 #ENDIF alloc
 #IF option("wifi") || option("ble")
 #IF option("defmt")
-#+embedded-io = { version = "0.6.1", features = ["defmt"] }
+#+embedded-io = { version = "0.6.1", features = ["defmt-03"] }
 #ELSE
 embedded-io = "0.6.1"
 #ENDIF defmt
 #IF option("embassy")
 #IF option("defmt")
-#+embedded-io-async = { version = "0.6.1", features = ["defmt"] }
+#+embedded-io-async = { version = "0.6.1", features = ["defmt-03"] }
 #ELSE
 embedded-io-async = "0.6.1"
 #ENDIF defmt


### PR DESCRIPTION
Update the embedded-io and embedded-io-async dependencies to utilize the `defmt-03` instead of unreachable `defmt` 

Please refer to the [document](https://docs.rs/embedded-io/0.6.1/embedded_io/#optional-cargo-features)