### PR TITLE
Deny `mem::forget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable `esp-wifi/smoltcp` when the dependency is present (#146)
 - Enable `defmt` or `log` on all crates that know them (#148)
 - The tool now prints the selected options (#154)
+- Enable the `clippy::mem_forget` lint since mem::forget is generall not safe to use with esp-hal. (#161)
 
 ### Changed
 

--- a/template/src/bin/async_main.rs
+++ b/template/src/bin/async_main.rs
@@ -1,6 +1,11 @@
 //INCLUDEFILE embassy src/bin/main.rs
 #![no_std]
 #![no_main]
+#![deny(
+    clippy::mem_forget,
+    reason = "mem::forget is generally not safe to do with esp_hal types, especially those \
+    holding buffers for the duration of a data transfer."
+)]
 
 use esp_hal::clock::CpuClock;
 //IF !option("esp32")

--- a/template/src/bin/main.rs
+++ b/template/src/bin/main.rs
@@ -1,6 +1,11 @@
 //INCLUDEFILE !embassy
 #![no_std]
 #![no_main]
+#![deny(
+    clippy::mem_forget,
+    reason = "mem::forget is generally not safe to do with esp_hal types, especially those \
+    holding buffers for the duration of a data transfer."
+)]
 
 use esp_hal::{
     clock::CpuClock,


### PR DESCRIPTION
Closes #156

This PR adds the lint deny to the source, so that we are able to provide a reason that is printed on the offending code. This is currently not possible to to from `Cargo.toml`.

Let me know what other lints we should specify (either allow or deny them).