### PR TITLE
Deduplicate options in help text

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,13 @@ struct Args {
     #[arg(short, long, help = {
         let mut all_options = Vec::new();
         for option in TEMPLATE.options.iter() {
-            all_options.extend(option.options());
+            for opt in option.options() {
+                // Remove duplicates, which usually are chip-specific variations of an option.
+                // An example of this is probe-rs.
+                if !all_options.contains(&opt) {
+                    all_options.push(opt);
+                }
+            }
         }
         format!("Generation options: {} - For more information regarding the different options check the esp-generate README.md (https://github.com/esp-rs/esp-generate/blob/main/README.md).",all_options.join(", "))
     })]


### PR DESCRIPTION
This PR removes the duplicate probe-rs entry from this help text:

```
  -o, --option <OPTION>            Generation options: unstable-hal, alloc, wifi, ble, embassy, stack-smashing-protection, probe-rs, probe-rs, defmt, panic-rtt-target, embedded-test, log, defmt, esp-backtrace, wokwi, dev-container, ci, helix, vscode - For more information regarding the different options check the esp-generate README.md (https://github.com/esp-rs/esp-generate/blob/main/README.md).
```