### PR TITLE
Update dev profile for debugging with `probe-rs`

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -214,6 +214,7 @@ embedded-test = { version = "0.6.0", features = [
 # Rust debug is too slow.
 # For debug builds always builds with some optimization
 opt-level = "s"
+codegen-units = 1        # LLVM can perform better optimizations using a single thread 
 
 [profile.release]
 codegen-units = 1        # LLVM can perform better optimizations using a single thread


### PR DESCRIPTION
With
```toml
[profile.dev]
opt-level = "s"
codegen-units = 1
```
I was able to somehow _debug_ examples using `wifi` or `PSRAM`.
<img width="757" alt="image" src="https://github.com/user-attachments/assets/fb779cd0-4290-45d7-91b4-288562ebbdff" />

closes https://github.com/esp-rs/esp-generate/issues/169