### PR TITLE
add clippy to fix nightly ci check missing component error

### DIFF
--- a/template/rust-toolchain.toml
+++ b/template/rust-toolchain.toml
@@ -5,7 +5,7 @@
 #ELSE
 channel    = "stable"
 #ENDIF
-components = ["rust-src"]
+components = ["rust-src", "clippy"]
 #REPLACE riscv32imac-unknown-none-elf rust_target
 targets = ["riscv32imac-unknown-none-elf"]
 #ELIF option("xtensa")


### PR DESCRIPTION
Error in CI, coming up on a few repos recently.

```bash
error: 'cargo-clippy' is not installed for the toolchain 'nightly-x86_64-unknown-linux-gnu'.
To install, run `rustup component add --toolchain nightly-x86_64-unknown-linux-gnu clippy`
```