### PR TITLE
Fix RTT without defmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The generated project no longer contains `template.yaml`. (#142)
 - Fixed parsing version output of old `espflash`. (#152)
 - Specified `defmt-03` feature for `embedded-io` and `embedded-io-async`. (#157)
+- Fixed RTT initialization without `defmt` (#183)
 
 ### Removed
 

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -38,7 +38,8 @@ esp-hal = { version = "1.0.0-beta.0", features = [
 #ELIF option("log")
 log = { version = "0.4.21" }
 #ENDIF
-#IF option("log-frontend") || option("panic-handler")
+
+#IF option("log-frontend") || option("panic-handler") || option("probe-rs")
 #IF option("probe-rs")
 #IF option("defmt")
 rtt-target = { version = "0.6.1", features = [ "defmt" ] }
@@ -57,7 +58,7 @@ esp-println = { version = "0.13.0", features = [
     #ENDIF
 ] }
 #ENDIF probe-rs
-#ENDIF log-frontend || panic-handler
+#ENDIF log-frontend || panic-handler || probe-rs
 #IF option("esp-backtrace")
 esp-backtrace = { version = "0.15.1", features = [
     #REPLACE esp32c6 mcu

--- a/template/src/bin/async_main.rs
+++ b/template/src/bin/async_main.rs
@@ -22,7 +22,9 @@ use esp_hal::timer::timg::TimerGroup;
 //+ use defmt::info;
 //ELIF option("log")
 use log::info;
-//ENDIF probe-rs
+//ELIF option("probe-rs") // without defmt
+use rtt_target::rprintln;
+//ENDIF !defmt
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
@@ -51,7 +53,7 @@ async fn main(spawner: Spawner) {
     //IF option("defmt")
     rtt_target::rtt_init_defmt!();
     //ELIF option("panic-rtt-target")
-    rtt_target::rtt_init!();
+    rtt_target::rtt_init_print!();
     //ENDIF
     //ELIF option("log")
     esp_println::logger::init_logger_from_env();
@@ -74,6 +76,8 @@ async fn main(spawner: Spawner) {
 
     //IF option("defmt") || option("log")
     info!("Embassy initialized!");
+    //ELIF option("probe-rs") // without defmt
+    rprintln!("Embassy initialized!");
     //ENDIF
 
     //IF option("wifi") || option("ble")
@@ -92,6 +96,8 @@ async fn main(spawner: Spawner) {
     loop {
         //IF option("defmt") || option("log")
         info!("Hello world!");
+        //ELIF option("probe-rs") // without defmt
+        rprintln!("Hello world!");
         //ENDIF
         Timer::after(Duration::from_secs(1)).await;
     }

--- a/template/src/bin/async_main.rs
+++ b/template/src/bin/async_main.rs
@@ -52,7 +52,7 @@ async fn main(spawner: Spawner) {
     //IF option("probe-rs")
     //IF option("defmt")
     rtt_target::rtt_init_defmt!();
-    //ELIF option("panic-rtt-target")
+    //ELSE
     rtt_target::rtt_init_print!();
     //ENDIF
     //ELIF option("log")

--- a/template/src/bin/main.rs
+++ b/template/src/bin/main.rs
@@ -50,7 +50,7 @@ fn main() -> ! {
     //IF option("probe-rs")
     //IF option("defmt")
     rtt_target::rtt_init_defmt!();
-    //ELIF option("panic-rtt-target")
+    //ELSE
     rtt_target::rtt_init_print!();
     //ENDIF
     //ELIF option("log")

--- a/template/src/bin/main.rs
+++ b/template/src/bin/main.rs
@@ -23,7 +23,9 @@ use esp_hal::timer::timg::TimerGroup;
 //+ use defmt::info;
 //ELIF option("log")
 use log::info;
-//ENDIF probe-rs
+//ELIF option("probe-rs") // without defmt
+use rtt_target::rprintln;
+//ENDIF !defmt
 
 //IF !option("panic-handler")
 //+#[panic_handler]
@@ -49,7 +51,7 @@ fn main() -> ! {
     //IF option("defmt")
     rtt_target::rtt_init_defmt!();
     //ELIF option("panic-rtt-target")
-    rtt_target::rtt_init!();
+    rtt_target::rtt_init_print!();
     //ENDIF
     //ELIF option("log")
     esp_println::logger::init_logger_from_env();
@@ -79,6 +81,8 @@ fn main() -> ! {
     loop {
         //IF option("defmt") || option("log")
         info!("Hello world!");
+        //ELIF option("probe-rs") // without defmt
+        rprintln!("Hello world!");
         //ENDIF
         let delay_start = Instant::now();
         while delay_start.elapsed() < Duration::from_millis(500) {}


### PR DESCRIPTION
`rtt_init` by default initializes 0 channels, which causes probe-rs to crash currently, and isn't useful besides.