### PR TITLE
Substitute esp-hal's version, check MSRV based on Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `rust-version` to the generated Cargo.toml (#192)
+
 ### Changed
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "taplo",
+ "toml_edit",
  "update-informer",
  "walkdir",
 ]
@@ -2058,6 +2059,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,6 +2593,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ taplo           = "0.14.0"
 update-informer = { version = "1.2.0", optional = true }
 serde           = { version = "1.0.219", features = ["derive"] }
 serde_yaml      = "0.9.34+deprecated"
+toml_edit       = "0.22.26"
 
 [build-dependencies]
 quote   = "1.0.40"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,0 +1,145 @@
+use std::error::Error;
+
+use toml_edit::{DocumentMut, Item, Value};
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+pub struct CargoToml {
+    pub manifest: toml_edit::DocumentMut,
+}
+
+const DEPENDENCY_KINDS: [&str; 3] = ["dependencies", "dev-dependencies", "build-dependencies"];
+
+impl CargoToml {
+    pub fn load(manifest: &str) -> Result<Self> {
+        // Parse the manifest string into a mutable TOML document.
+        Ok(Self {
+            manifest: manifest.parse::<DocumentMut>()?,
+        })
+    }
+
+    pub fn is_published(&self) -> bool {
+        // Check if the package is published by looking for the `publish` key
+        // in the manifest.
+        let Item::Table(package) = &self.manifest["package"] else {
+            unreachable!("The package table is missing in the manifest");
+        };
+
+        let Some(publish) = package.get("publish") else {
+            return true;
+        };
+
+        publish.as_bool().unwrap_or(true)
+    }
+
+    pub fn version(&self) -> &str {
+        self.manifest["package"]["version"]
+            .as_str()
+            .unwrap()
+            .trim()
+            .trim_matches('"')
+    }
+
+    pub fn msrv(&self) -> &str {
+        self.manifest["package"]["rust-version"]
+            .as_str()
+            .unwrap()
+            .trim()
+            .trim_matches('"')
+    }
+
+    /// Calls a callback for each table that contains dependencies.
+    ///
+    /// Callback arguments:
+    /// - `path`: The path to the table (e.g. `dependencies.package`)
+    /// - `dependency_kind`: The kind of dependency (e.g. `dependencies`,
+    ///   `dev-dependencies`)
+    /// - `table`: The table itself
+    pub fn visit_dependencies(
+        &self,
+        mut handle_dependencies: impl FnMut(&str, &'static str, &toml_edit::Table),
+    ) {
+        fn recurse_dependencies(
+            path: String,
+            table: &toml_edit::Table,
+            handle_dependencies: &mut impl FnMut(&str, &'static str, &toml_edit::Table),
+        ) {
+            // Walk through tables recursively so that we can find *all* dependencies.
+            for (key, item) in table.iter() {
+                if let Item::Table(table) = item {
+                    let path = if path.is_empty() {
+                        key.to_string()
+                    } else {
+                        format!("{path}.{key}")
+                    };
+                    recurse_dependencies(path, table, handle_dependencies);
+                }
+            }
+            for dependency_kind in DEPENDENCY_KINDS {
+                let Some(Item::Table(table)) = table.get(dependency_kind) else {
+                    continue;
+                };
+
+                handle_dependencies(&path, dependency_kind, table);
+            }
+        }
+
+        recurse_dependencies(
+            String::new(),
+            self.manifest.as_table(),
+            &mut handle_dependencies,
+        );
+    }
+
+    pub fn dependency_version(&self, package_name: &str) -> String {
+        let mut dep_version = String::new();
+        self.visit_dependencies(|_, _, table| {
+            // Update dependencies which specify a version:
+            if !table.contains_key(package_name) {
+                return;
+            }
+            match &table[package_name] {
+                Item::Value(Value::String(value)) => {
+                    // package = "version"
+                    dep_version = value.value().to_string();
+                }
+                Item::Table(table) if table.contains_key("version") => {
+                    // [package]
+                    // version = "version"
+                    dep_version = table["version"].as_value().unwrap().to_string();
+                }
+                Item::Value(Value::InlineTable(table)) if table.contains_key("version") => {
+                    // package = { version = "version" }
+                    dep_version = table["version"].as_str().unwrap().to_string();
+                }
+                Item::None => {
+                    // alias = { package = "foo", version = "version" }
+                    let update_renamed_dep = table.get_values().iter().find_map(|(k, p)| {
+                        if let Value::InlineTable(table) = p {
+                            if let Some(Value::String(name)) = &table.get("package") {
+                                if name.value() == package_name {
+                                    // Return the actual key of this dependency, e.g.:
+                                    // `procmacros = { package = "esp-hal-procmacros" }`
+                                    //  ^^^^^^^^^^
+                                    return Some(k.last().unwrap().get().to_string());
+                                }
+                            }
+                        }
+
+                        None
+                    });
+
+                    if let Some(dependency_name) = update_renamed_dep {
+                        dep_version = table[&dependency_name]["version"]
+                            .as_value()
+                            .unwrap()
+                            .to_string();
+                    }
+                }
+                _ => {}
+            }
+        });
+
+        dep_version.trim_start_matches('=').to_string()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cargo;
 pub mod config;
 pub mod template;
 

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -3,6 +3,7 @@
 name = "project-name"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.86"
 
 [[bin]]
 #REPLACE project-name project-name

--- a/template/src/bin/async_main.rs
+++ b/template/src/bin/async_main.rs
@@ -124,5 +124,6 @@ async fn main(spawner: Spawner) {
         Timer::after(Duration::from_secs(1)).await;
     }
 
-    // for inspiration have a look at the examples at https://github.com/esp-rs/esp-hal/tree/esp-hal-v1.0.0-beta.1/examples/src/bin
+    //REPLACE {current-version} esp-hal-version {current-version} esp-hal-version
+    // for inspiration have a look at the examples at https://github.com/esp-rs/esp-hal/tree/esp-hal-v{current-version}/examples/src/bin
 }

--- a/template/src/bin/main.rs
+++ b/template/src/bin/main.rs
@@ -92,5 +92,6 @@ fn main() -> ! {
         while delay_start.elapsed() < Duration::from_millis(500) {}
     }
 
-    // for inspiration have a look at the examples at https://github.com/esp-rs/esp-hal/tree/esp-hal-v1.0.0-beta.1/examples/src/bin
+    //REPLACE {current-version} esp-hal-version
+    // for inspiration have a look at the examples at https://github.com/esp-rs/esp-hal/tree/esp-hal-v{current-version}/examples/src/bin
 }


### PR DESCRIPTION
Probably mostly addresses #89 by:

- Adding `rust-version` to Cargo.toml. This is a bit fragile as we need to hand-maintain it, but tools like cargo-msrv exist.
- Parsing esp-hal version out of Cargo.toml, by using largely the same code as esp-hal's release tooling. This version is then injected back into the template.