### PR TITLE
Add interactive flow option instead of setting target chip and name in arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added interactive flow option instead of setting target chip and name in arguments (#196)
 
 - Added `rust-version` to the generated Cargo.toml (#192)
 - Generate settings for Zed (#200)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ default = ["update-informer"]
 update-informer = ["dep:update-informer"]
 
 [dependencies]
+inquire = "0.7.5"
 clap            = { version = "4.5.39", features = ["derive"] }
 crossterm       = "0.29.0"
 env_logger      = "0.11.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ default = ["update-informer"]
 update-informer = ["dep:update-informer"]
 
 [dependencies]
-strum = "0.27.1"
-inquire = "0.7.5"
+strum           = "0.27.1"
+inquire         = "0.7.5"
 clap            = { version = "4.5.39", features = ["derive"] }
 crossterm       = "0.29.0"
 env_logger      = "0.11.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ default = ["update-informer"]
 update-informer = ["dep:update-informer"]
 
 [dependencies]
+strum = "0.27.1"
 inquire = "0.7.5"
 clap            = { version = "4.5.39", features = ["derive"] }
 crossterm       = "0.29.0"

--- a/README.md
+++ b/README.md
@@ -25,10 +25,9 @@ You can also directly download pre-compiled [release binaries] or use [`cargo-bi
    1. Using the Terminal User Interface (TUI):
 
       ```
-      esp-generate --chip esp32 your-project
+      esp-generate
       ```
-
-      Replace the chip and project name accordingly, and select the desired options using the TUI.
+      You will be prompted to select a target chip and name for your project, after which you would use TUI to select the other options you need for your project.
 
    2. Using the Command Line Interface (CLI), adding the options to the `esp-generate` command:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,15 +7,15 @@ use std::{
     sync::LazyLock,
 };
 
-use strum::IntoEnumIterator;
 use clap::Parser;
 use env_logger::{Builder, Env};
 use esp_generate::config::{ActiveConfiguration, Relationships};
 use esp_generate::template::{GeneratorOptionItem, Template};
 use esp_generate::{cargo, config::find_option};
 use esp_metadata::Chip;
+use inquire::{Select, Text};
+use strum::IntoEnumIterator;
 use taplo::formatter::Options;
-use inquire::{Text, Select};
 
 use crate::template_files::TEMPLATE_FILES;
 
@@ -96,13 +96,17 @@ fn setup_args_interactive(args: &mut Args) -> Result<(), Box<dyn Error>> {
 
         let chip_index = Select::new("Select your target chip:", chip_names.clone())
             .prompt()
-            .map(|selected| chip_names.iter().position(|&name| name == selected).unwrap())?;
+            .map(|selected| {
+                chip_names
+                    .iter()
+                    .position(|&name| name == selected)
+                    .unwrap()
+            })?;
 
         args.chip = Some(chip_variants[chip_index].clone());
     }
 
     if args.name.is_none() {
-
         let project_name = Text::new("Enter project name:")
             .with_default("my-esp-project")
             .prompt()?;
@@ -561,11 +565,7 @@ fn process_options(template: &Template, args: &Args) {
             log::error!("Unknown option '{}'", option);
             success = false;
         } else if !option_found_for_chip {
-            log::error!(
-                "Option '{}' is not supported for chip {}",
-                option,
-                arg_chip
-            );
+            log::error!("Option '{}' is not supported for chip {}", option, arg_chip);
             success = false;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,13 @@ fn check_for_update(name: &str, version: &str) {
 }
 
 fn setup_args_interactive(args: &mut Args) -> Result<(), Box<dyn Error>> {
+    if args.headless {
+        log::error!(
+            "You can't use TUI to set the target chip or output directory name in headless mode"
+        );
+        process::exit(-1);
+    }
+
     if args.chip.is_none() {
         let chip_variants = Chip::iter().collect::<Vec<_>>();
 
@@ -124,19 +131,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // Run the interactive TUI only if chip or name is missing
-    if (args.chip.is_none() || args.name.is_none()) && !args.headless {
+    if args.chip.is_none() || args.name.is_none() {
         setup_args_interactive(&mut args)?;
     }
 
-    let Some(chip) = args.chip else {
-        log::error!("Chip was not set");
-        process::exit(-1);
-    };
+    let chip = args.chip.unwrap();
 
-    let Some(name) = args.name.clone() else {
-        log::error!("Output directory name was not set");
-        process::exit(-1);
-    };
+    let name = args.name.clone().unwrap();
 
     let path = &args
         .output_path

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn setup_args_interactive(args: &mut Args) -> Result<(), Box<dyn Error>> {
                     .unwrap()
             })?;
 
-        args.chip = Some(chip_variants[chip_index].clone());
+        args.chip = Some(chip_variants[chip_index]);
     }
 
     if args.name.is_none() {
@@ -137,7 +137,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         setup_args_interactive(&mut args)?;
     }
 
-    let chip = args.chip.clone().unwrap();
+    let chip = args.chip.unwrap();
     let name = args.name.clone().unwrap();
 
     let path = &args


### PR DESCRIPTION
closes #174 

If user still will pass `--chip` and `<NAME>` in arguments, they will just proceed to our classic TUI

https://github.com/user-attachments/assets/aa3bd669-92c6-4698-85e0-2c35c03cafae

