### PR TITLE
docs(README): update BLE and editor feature descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ You can also directly download pre-compiled [release binaries] or use [`cargo-bi
 - `unstable-hal`: Enables esp-hal features that may not be ready for general use yet.
 - `alloc`: Enables allocations via the `esp-alloc` crate.
 - `wifi`: Enables Wi-Fi via the `esp-wifi` crate; requires `alloc`.
-- `ble`: Enables BLE via the `esp-wifi` crate; requires `alloc`.
+- `ble-bleps`: Enables BLE via the `esp-wifi` crate using `bleps`; requires `alloc`, mutually exclusive with `ble-trouble`.
+- `ble-trouble`: Enables BLE via the `esp-wifi`crate using `embassy-trouble`; requires `alloc`, mutually exclusive with `ble-bleps`.
 - `embassy`: Adds `embassy` framework support.
 - `stack-smashing-protection`: Enables [stack smashing protection](https://doc.rust-lang.org/rustc/exploit-mitigations.html#stack-smashing-protection). Requires nightly Rust.
 - `probe-rs`: Replaces `espflash` with `probe-rs` and enables RTT-based options.
@@ -63,8 +64,9 @@ You can also directly download pre-compiled [release binaries] or use [`cargo-bi
   - `dev-container`: Adds support for [VS Code Dev Containers] and [GitHub Codespaces].
   - `ci` Adds GitHub Actions support with some basics checks.
 - `editors`: Select the editor integrations:
-   - `helix`: The Helix Editor
+   - `helix`: The Helix editor
    - `vscode`: Visual Studio Code
+   - `zed`: The Zed editor
 
 [VS Code Wokwi extension]: https://marketplace.visualstudio.com/items?itemName=wokwi.wokwi-vscode
 [VS Code Dev Containers]: https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container


### PR DESCRIPTION
There are a few new options available in both the CLI and the TUI:

```
  -o, --option <OPTION>
          Generation options: unstable-hal, alloc, wifi, ble-bleps, ble-trouble, embassy, stack-smashing-protection, probe-rs, defmt, panic-rtt-target, embedded-test, log, esp-backtrace, wokwi, dev-container, ci, helix, vscode, zed - For more information regarding the different options check the esp-generate README.md (https://github.com/esp-rs/esp-generate/blob/main/README.md).
```

This adds the options to the README.