### PR TITLE
Don't ignore .vscode if vscode options are selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Don't gitignore .vscode if the vscode option is selected (#218)
 
 ### Fixed
 

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,7 +1,9 @@
 # will have compiled files and executables
 debug/
 target/
+//IF !option("vscode")
 .vscode/
+//ENDIF
 .zed/
 .helix/
 


### PR DESCRIPTION
- If the vscode option is selected, my thoughts were that it'd seem likely the user would want the .vscode folder to persist
- As such, conditionally not ignoring that folder if the user has selected vscode option