### PR TITLE
Swap linker script order, again

### DIFF
--- a/template/build.rs
+++ b/template/build.rs
@@ -3,11 +3,12 @@ fn main() {
     //IF option("embedded-test")
     println!("cargo:rustc-link-arg-tests=-Tembedded-test.x");
     //ENDIF
+    println!("cargo:rustc-link-arg=-Tlinkall.x");
     //IF option("defmt")
+    // defmt.x can't be the last linker script, or you'll likely get this error:
+    // `failed to demangle defmt symbol `__global_pointer$`: expected value at line 1 column 1`
     println!("cargo:rustc-link-arg=-Tdefmt.x");
     //ENDIF
-    // make sure linkall.x is the last linker script (otherwise might cause problems with flip-link)
-    println!("cargo:rustc-link-arg=-Tlinkall.x");
 }
 
 fn linker_be_nice() {


### PR DESCRIPTION
This modified `dhcp` example demonstrates the issue: https://github.com/esp-rs/esp-hal/commit/42b17353b732609873f05768dc4dbbb1dc87a444

If you swap `defmt.x` and `linkall.x`, things stop working. Placing defmt.x last no longer seems to cause a flip-link issue, for some reason.