### PR TITLE
fix panic due to padding overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fixed cases where padding overflow caused panic if terminal size changed (#228)
 
 ### Removed
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -114,7 +114,8 @@ impl<'app> Repository<'app> {
                     } else {
                         style.unselected
                     };
-                let padding = width as usize - v.title().len() - 4; // 2 spaces + the indicator
+                // reserve indicator spacing; saturating_sub keeps padding non-negative so narrow widths don't overflow
+                let padding = (width as usize).saturating_sub(v.title().len() + 4);
                 (
                     level_active && self.config.is_active(v),
                     format!(


### PR DESCRIPTION
### Summary

  - Prevent panic in tui.rs:117 triggered when the terminal shrinks.

### Reproduction

  - Launch esp-generate, enter fullscreen, and enter any MCU and project name, don't confirm yet.
  - Exit fullscreen, open another terminal so the terminal is roughly half of its original size.
  - Press Enter to confirm the project name; observe attempt to subtract with overflow from
  src/tui.rs:117:31.

### Fix

  - Use core::saturating_sub when computing padding so it never goes negative, preserving
  formatting without risking overflow.
