### PR TITLE
Update template with bt-hci version used by esp-wifi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Updated bt-hci and trouble-host dependencies
 
 ### Fixed
 - Fixed cases where padding overflow caused panic if terminal size changed (#228)

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -164,8 +164,8 @@ esp-wifi = { version = "0.15.0", features = [
 #+bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "a5148d8ae679e021b78f53fd33afb8bb35d0b62e", features = [ "macros", "async"] }
 #ENDIF
 #IF option("ble-trouble")
-#+trouble-host = { version = "0.1.0", features = ["gatt"] }
-#+bt-hci = { version = "0.2.1", features = [] }
+#+trouble-host = { version = "0.2.4", features = ["gatt"] }
+#+bt-hci = { version = "0.3.2", features = [] }
 #ENDIF
 #ENDIF wifi || ble || ble-trouble
 #IF option("embassy")

--- a/template/src/bin/async_main.rs
+++ b/template/src/bin/async_main.rs
@@ -20,6 +20,7 @@ use esp_wifi::ble::controller::BleConnector;
 //ENDIF
 //IF option("ble-trouble")
 use bt_hci::controller::ExternalController;
+use trouble_host::prelude::*;
 //ENDIF
 
 //IF option("defmt")
@@ -49,6 +50,11 @@ use esp_backtrace as _;
 
 //IF option("alloc")
 extern crate alloc;
+//ENDIF
+
+//IF option("ble-trouble")
+const CONNECTIONS_MAX: usize = 1;
+const L2CAP_CHANNELS_MAX: usize = 1;
 //ENDIF
 
 // This creates a default app-descriptor required by the esp-idf bootloader.
@@ -108,7 +114,10 @@ async fn main(spawner: Spawner) {
     //IF option("ble-trouble")
     // find more examples https://github.com/embassy-rs/trouble/tree/main/examples/esp32
     let transport = BleConnector::new(&wifi_init, peripherals.BT);
-    let _ble_controller = ExternalController::<_, 20>::new(transport);
+    let ble_controller = ExternalController::<_, 20>::new(transport);
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
+    let _stack = trouble_host::new(ble_controller, &mut resources);
     //ELIF option("ble-bleps")
     let _connector = BleConnector::new(&wifi_init, peripherals.BT);
     //ENDIF


### PR DESCRIPTION
**Problem description**
Cannot use [embassy-rs/trouble](https://github.com/embassy-rs/trouble) in a project created with esp-generate v0.5.0. 

**Steps to reproduce**
1) Create a new project with `esp-generate -c esp32 -o unstable-hal -o alloc -o ble-trouble -o embassy project`
2) Add the following to `main`:
```
    use trouble_host::prelude::*;
    let mut resources: HostResources<1, 1, 255> = HostResources::new();
    let stack = trouble_host::new(_ble_controller, &mut resources);
```
3) `cargo build` produces this error:
```
error[E0277]: the trait bound `BleConnector<'_>: bt_hci::transport::Transport` is not satisfied
   --> src/bin/main.rs:52:35
    |
52  |     let stack = trouble_host::new(_ble_controller, &mut resources);
    |                 ----------------- ^^^^^^^^^^^^^^^ the trait `bt_hci::transport::Transport` is not implemented for `BleConnector<'_>`
    |                 |
    |                 required by a bound introduced by this call
    |
help: trait impl with same name found
   --> /home/yanome/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/esp-wifi-0.15.0/src/ble/controller/mod.rs:180:5
    |
180 |     impl Transport for BleConnector<'_> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `bt_hci` are being used?
note: there are multiple different versions of crate `bt_hci` in the dependency graph
   --> /home/yanome/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bt-hci-0.2.1/src/transport.rs:13:1
    |
13  | pub trait Transport: embedded_io::ErrorType {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this is the required trait
    |
   ::: src/bin/main.rs:9:5
    |
9   | use bt_hci::controller::ExternalController;
    |     ------ one version of crate `bt_hci` used here, as a direct dependency of the current crate
...
14  | use esp_wifi::ble::controller::BleConnector;
    |     -------- one version of crate `bt_hci` used here, as a dependency of crate `esp_wifi`
    |
   ::: /home/yanome/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/esp-wifi-0.15.0/src/ble/controller/mod.rs:7:1
    |
7   | pub struct BleConnector<'d> {
    | --------------------------- this type doesn't implement the required trait
    |
   ::: /home/yanome/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bt-hci-0.3.2/src/fmt.rs:219:1
    |
219 | pub trait Try {
    | ------------- this is the found trait
    = help: you can use `cargo tree` to explore your dependency tree
    = note: required for `ExternalController<BleConnector<'_>, 20>` to implement `bt_hci::controller::Controller`
    = note: required for `ExternalController<BleConnector<'_>, 20>` to implement `trouble_host::Controller`
note: required by a bound in `trouble_host::new`
   --> /home/yanome/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trouble-host-0.1.0/src/lib.rs:416:8
    |
414 | pub fn new<
    |        --- required by a bound in this function
415 |     'resources,
416 |     C: Controller,
    |        ^^^^^^^^^^ required by this bound in `new`

For more information about this error, try `rustc --explain E0277`.
```

**Proposed solution**
- Update the template to use `bt-hci` v0.3.2, same as `esp-wifi` v0.15.0.
- Update the template to use `trouble-host` v0.2.4 that uses `bt-hci` v0.3.2.

**Test**
1) Create a new project.
2) The `HostResources` struct changed between versions, add:
```
    use trouble_host::prelude::*;
    let mut resources: HostResources<DefaultPacketPool, 1, 1> = HostResources::new();
    let stack = trouble_host::new(_ble_controller, &mut resources);
```
3) Run `cargo build`.
