### PR TITLE
Helix: switch check.allTargets to cargo.allTargets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Helix config: set cargo.allTargets to false
+
 ### Fixed
 
 ### Removed

--- a/template/.helix/languages.toml
+++ b/template/.helix/languages.toml
@@ -8,7 +8,7 @@ environment.RUSTUP_TOOLCHAIN = "stable"
 
 #ENDIF
 [language-server.rust-analyzer.config]
-check.allTargets = false
+cargo.allTargets = false
 #REPLACE riscv32imac-unknown-none-elf rust_target
 cargo.target = "riscv32imac-unknown-none-elf"
 #IF option("xtensa")


### PR DESCRIPTION
Brings the Helix config in line with the other editors.

Closes #245