### PR TITLE
Fix enabling RTT for debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `"rttEnabled": true` is now set even if `defmt` is not enabled (#255)
+
 ### Removed
 
 ## [1.0.1] - 2025-11-05

--- a/template/.vscode/launch.json
+++ b/template/.vscode/launch.json
@@ -23,8 +23,8 @@
                     "coreIndex": 0,
                     //REPLACE riscv32imc-unknown-none-elf rust_target
                     "programBinary": "target/riscv32imc-unknown-none-elf/debug/${workspaceFolderBasename}",
-                    //IF option("defmt")
                     "rttEnabled": true,
+                    //IF option("defmt")
                     "rttChannelFormats": [
                         {
                             "channelNumber": 0,
@@ -47,8 +47,8 @@
                     "coreIndex": 0,
                     //REPLACE riscv32imc-unknown-none-elf rust_target
                     "programBinary": "target/riscv32imc-unknown-none-elf/debug/${workspaceFolderBasename}",
-                    //IF option("defmt")
                     "rttEnabled": true,
+                    //IF option("defmt")
                     "rttChannelFormats": [
                         {
                             "channelNumber": 0,


### PR DESCRIPTION
Currently the probe-rs option implies that RTT will be used. However, we only set `"rttEnabled": true,` for defmt, which means that if you only use rtt-target, you get no log output during debugging.