### PR TITLE
Don't be over dramatic about missing probe-rs if it's not needed

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -442,7 +442,7 @@ Checking installed versions
 Checking installed versions
 🆗 Rust (nightly): 1.85.0
 🆗 espflash: 3.3.0
-❌ probe-rs (not found - see https://probe.rs/docs/getting-started/installation/ for how to install (suggested))
+💡 probe-rs (not found - see https://probe.rs/docs/getting-started/installation/ for how to install (suggested))
 🆗 esp-config: 0.5.0
 "
             .to_string()


### PR DESCRIPTION
Closes #171 (if it's only about probe-rs)

`skip-changelog` - I could add a changelog entry but not sure it's worth it for this 🤷‍♂️ 

