### PR TITLE
More linker hints

### DIFF
--- a/template/build.rs
+++ b/template/build.rs
@@ -18,7 +18,7 @@ fn linker_be_nice() {
 
         match kind.as_str() {
             "undefined-symbol" => match what.as_str() {
-                kind if kind.starts_with("_defmt_") => {
+                what if what.starts_with("_defmt_") => {
                     eprintln!();
                     eprintln!(
                         "💡 `defmt` not found - make sure `defmt.x` is added as a linker script and you have included `use defmt_rtt as _;`"
@@ -30,7 +30,7 @@ fn linker_be_nice() {
                     eprintln!("💡 Is the linker script `linkall.x` missing?");
                     eprintln!();
                 }
-                kind if kind.starts_with("esp_rtos_") => {
+                what if what.starts_with("esp_rtos_") => {
                     eprintln!();
                     eprintln!(
                         "💡 `esp-radio` has no scheduler enabled. Make sure you have initialized `esp-rtos` or provided an external scheduler."


### PR DESCRIPTION
Closes #256

`skip-changelog` since it's not really relevant

This adds all the linker errors I could easily repro by "forgetting" dependencies

Technically we already had hints for esp-rtos but since we now have a lot more symbols it was only revealed by scrolling up
