### PR TITLE
Fix footer hint and title text color (`Light` MacOS appearance)

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -357,6 +357,7 @@ impl App<'_> {
         Paragraph::new("esp-generate")
             .bold()
             .centered()
+            .fg(self.colors.text_color)
             .bg(self.colors.app_background)
             .render(area, buf);
     }
@@ -486,6 +487,7 @@ impl App<'_> {
 
         Paragraph::new(text)
             .centered()
+            .fg(self.colors.text_color) 
             .bg(self.colors.app_background)
             .wrap(Wrap { trim: false })
     }


### PR DESCRIPTION
closes https://github.com/esp-rs/esp-generate/issues/261
before:
<img width="588" height="392" alt="image" src="https://github.com/user-attachments/assets/b53bf615-2bf2-407f-8e80-4aa5c6bda822" />

after: 
<img width="594" height="388" alt="image" src="https://github.com/user-attachments/assets/7fec3de9-85b3-4e9d-9609-5291b86f9df8" />
