### PR TITLE
Show the `esp-*` crate versions in the help message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ fn about() -> String {
             for entry in table.iter() {
                 let name = entry.0;
                 if name.starts_with("esp-") {
-                    about.push_str(&format!("{} => {}\n", name, toml.dependency_version(name)));
+                    about.push_str(&format!("{:23 } {}\n", name, toml.dependency_version(name)));
                 }
             }
         }


### PR DESCRIPTION
Closes #260 

This will augment the output of `--help` with the versions of the `esp-*` crates used in the template.

```
❯ cargo run -- --help
   Compiling esp-generate v1.1.0 (D:\projects\esp\esp-generate)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.46s
     Running `target\debug\esp-generate.exe --help`
Template generation tool to create no_std applications targeting Espressif's chips.

The template will use these versions:
esp-hal => ~1.0
esp-rtos => 0.2.0
esp-bootloader-esp-idf => 0.4.0
esp-println => 0.16.1
esp-backtrace => 0.18.1
esp-alloc => 0.9.0
esp-radio => 0.17.0


Usage: esp-generate.exe [OPTIONS] [NAME]

Arguments:
  [NAME]
          Name of the project to generate

Options:
  -c, --chip <CHIP>
          Chip to target

          Possible values:
          - esp32:   ESP32
          - esp32c2: ESP32-C2, ESP8684
          - esp32c3: ESP32-C3, ESP8685
          - esp32c6: ESP32-C6
          - esp32h2: ESP32-H2
          - esp32s2: ESP32-S2
          - esp32s3: ESP32-S3

      --headless
          Run in headless mode (i.e. do not use the TUI)

  -o, --option <OPTION>
          Generation options: unstable-hal, alloc, wifi, ble-bleps, ble-trouble, embassy, stack-smashing-protection, probe-rs, defmt, panic-rtt-target, embedded-test, log, esp-backtrace, wokwi, ci, helix, neovim, vscode, zed, PLACEHOLDER - For more information regarding the different options check the esp-generate README.md (https://github.com/esp-rs/esp-generate/blob/main/README.md).

  -O, --output-path <OUTPUT_PATH>
          Directory in which to generate the project

  -s, --skip-update-check
          Do not check for updates

      --toolchain <TOOLCHAIN>
          Rust toolchain to use (rustup toolchain name; must support the selected chip target)

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version

```

Maybe we should also include this as the body-text of the release? (I don't know exactly how to do this but the used `upload-release-action`  has a `body` parameter)
