### PR TITLE
Add `--disable-emojis` cli argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Prompt user to install a missing or outdated tool (#270)
+- Add `--disable-emojis` option
 
 ### Changed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,10 @@ struct Args {
     /// Rust toolchain to use (rustup toolchain name; must support the selected chip target)
     #[arg(long)]
     toolchain: Option<String>,
+
+    /// Use ASCII characters to display selected options instead of emojis
+    #[arg(long, action)]
+    disable_emojis: bool,
 }
 
 /// Check crates.io for a new version of the application
@@ -236,7 +240,7 @@ fn main() -> Result<()> {
         let terminal = tui::init_terminal()?;
 
         // create app and run it
-        let selected = tui::App::new(repository).run(terminal)?;
+        let selected = tui::App::new(repository, args.disable_emojis).run(terminal)?;
 
         tui::restore_terminal()?;
         // done with the TUI

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -235,13 +235,15 @@ pub struct App<'app> {
 }
 
 impl<'app> App<'app> {
-    pub fn new(repository: Repository<'app>) -> Self {
+    pub fn new(repository: Repository<'app>, disable_emojis: bool) -> Self {
         let mut initial_state = ListState::default();
         initial_state.select(Some(0));
 
-        let (ui_elements, colors) = match std::env::var("TERM_PROGRAM").as_deref() {
-            Ok("vscode") => (UiElements::FALLBACK, Colors::RGB),
-            Ok("Apple_Terminal") => (UiElements::FALLBACK, Colors::ANSI),
+        let (ui_elements, colors) = match (std::env::var("TERM_PROGRAM").as_deref(), disable_emojis)
+        {
+            (Ok("vscode"), _) => (UiElements::FALLBACK, Colors::RGB),
+            (Ok("Apple_Terminal"), _) => (UiElements::FALLBACK, Colors::ANSI),
+            (_, true) => (UiElements::FALLBACK, Colors::RGB),
             _ => (UiElements::FANCY, Colors::RGB),
         };
 


### PR DESCRIPTION
Add `--disable-emojis` option to cli arguments to force the use of the fallback ui elements (\* and >) instead of emojis (✅ and ▶️).