### PR TITLE
Preverify before launching a debug session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- VSCode debugger launch configuration now sets `verifyBeforeFlashing` to `true` (#290)
+
 ### Changed
 
 ### Fixed

--- a/template/.vscode/launch.json
+++ b/template/.vscode/launch.json
@@ -14,6 +14,7 @@
             "flashingConfig": {
                 "flashingEnabled": true,
                 "haltAfterReset": true,
+                "verifyBeforeFlashing": true,
                 "formatOptions": {
                     "binaryFormat": "idf"
                 }


### PR DESCRIPTION
`verifyBeforeFlashing` lets probe-rs skip flashing if the binary doesn't change.