### PR TITLE
Add --bsp option to use external Board Support Package templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ serde           = { version = "1.0.228", features = ["derive"] }
 serde_yaml      = "0.9.33"
 toml_edit       = "0.23.9"
 indexmap = "2.13.0"
+walkdir         = "2.5.0"
+quote           = "1.0.43"
 
 [build-dependencies]
 quote   = "1.0.43"

--- a/build.rs
+++ b/build.rs
@@ -1,53 +1,9 @@
+mod template_embed {
+    include!("src/template_embed.rs");
+}
+
 fn main() {
-    let cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
-    let cwd = cwd.to_str().unwrap();
-    let mut files: Vec<(String, String)> = Vec::new();
-
-    for file in walkdir::WalkDir::new("template") {
-        let path = file.unwrap();
-
-        if !path.file_type().is_file() {
-            continue;
-        }
-
-        let path = path.path();
-
-        let relative_path = path
-            .canonicalize()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .strip_prefix(cwd)
-            .unwrap()
-            .to_string()
-            .replace("\\", "/");
-
-        let relative_path = relative_path
-            .strip_prefix("/template/")
-            .unwrap()
-            .to_string();
-
-        if relative_path.starts_with("target/") {
-            continue;
-        }
-
-        //println!("{:?} {}", path, relative_path);
-        let content = std::fs::read_to_string(path).unwrap();
-
-        files.push((relative_path, content));
-    }
-
-    let mut files_code = Vec::new();
-    for (file, content) in files {
-        files_code.push(quote::quote! { (#file, #content) })
-    }
-
-    let code = quote::quote! {
-        pub static TEMPLATE_FILES: &[(&str, &str)] = &[
-            #(#files_code),*
-        ];
-    };
-
-    std::fs::write("src/template_files.rs", code.to_string().as_bytes()).unwrap();
+    let code = template_embed::generate_template_files_code();
+    std::fs::write("src/template_files.rs", code.as_bytes()).unwrap();
     println!("cargo:rerun-if-changed=template");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cargo;
 pub mod config;
 pub mod modules;
 pub mod template;
+pub mod template_embed;
 
 /// This turns a list of strings into a sentence, and appends it to the base string.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use strum::IntoEnumIterator;
 use taplo::formatter::Options;
 
 use crate::template_files::TEMPLATE_FILES;
+use esp_generate::template_embed;
 
 mod check;
 mod module_selector;
@@ -50,9 +51,15 @@ struct Args {
     /// Name of the project to generate
     name: Option<String>,
 
-    /// Chip to target
-    #[arg(short, long)]
+    /// Chip to target (mutually exclusive with --bsp)
+    #[arg(short, long, conflicts_with = "bsp")]
     chip: Option<Chip>,
+
+    /// Board Support Package path or name (mutually exclusive with --chip)
+    /// If a valid local path, uses that as template source.
+    /// If not a valid path, downloads from git repository (not yet implemented).
+    #[arg(long, conflicts_with = "chip")]
+    bsp: Option<String>,
 
     /// Run in headless mode (i.e. do not use the TUI)
     #[arg(long)]
@@ -316,6 +323,31 @@ fn main() -> Result<()> {
     if let Some(subcommand) = args.subcommands {
         return subcommand.handle();
     }
+    // Handle --bsp argument
+    let bsp_template_files: Option<&[(&str, &str)]> = if let Some(bsp) = &args.bsp {
+        let bsp_path_str = if bsp.starts_with('~') {
+            if let Ok(home) = std::env::var("HOME") {
+                bsp.replacen('~', &home, 1)
+            } else {
+                bsp.clone()
+            }
+        } else {
+            bsp.clone()
+        };
+        let bsp_path = Path::new(&bsp_path_str);
+        if bsp_path.exists() && bsp_path.is_dir() {
+            // Use local path as template source
+            Some(template_embed::embed_templates_from_path(bsp_path))
+        } else {
+            // Not a valid local path - assume it's a BSP name for git download (not implemented)
+            unimplemented!("BSP '{}' is not a valid local path. Git repository download not yet implemented.", bsp);
+        }
+    } else {
+        None
+    };
+
+    // Determine which template files to use
+    let template_files = bsp_template_files.unwrap_or(TEMPLATE_FILES);
 
     // Only check for updates once the command-line arguments have been processed,
     // to avoid printing any update notifications when the help message is
@@ -330,7 +362,14 @@ fn main() -> Result<()> {
         setup_args_interactive(&mut args)?;
     }
 
-    let chip = args.chip.unwrap();
+    // When using --bsp, get chip from template; otherwise use CLI argument
+    let chip = if args.bsp.is_some() {
+        let template_chip = get_chip_from_bsp_template(template_files);
+        args.chip = Some(template_chip);
+        template_chip
+    } else {
+        args.chip.unwrap()
+    };
 
     let name = args.name.clone().unwrap();
 
@@ -348,7 +387,7 @@ fn main() -> Result<()> {
     }
 
     let versions = cargo::CargoToml::load(
-        TEMPLATE_FILES
+        template_files
             .iter()
             .find(|(k, _)| *k == "Cargo.toml")
             .expect("Cargo.toml not found in template")
@@ -380,7 +419,19 @@ fn main() -> Result<()> {
         ))
     };
 
-    let mut template = TEMPLATE.clone();
+    // Parse template - use BSP template_files if --bsp was specified, otherwise use built-in
+    let template = if args.bsp.is_some() {
+        serde_yaml::from_str(
+            template_files
+                .iter()
+                .find_map(|(k, v)| if *k == "template.yaml" { Some(v) } else { None })
+                .expect("template.yaml not found in BSP template"),
+        )
+        .expect("Failed to parse BSP template.yaml")
+    } else {
+        TEMPLATE.clone()
+    };
+    let mut template = template;
     remove_incompatible_chip_options(chip, &mut template.options);
     module_selector::populate_module_category(chip, &mut template.options);
     process_options(&template, &args)?;
@@ -597,7 +648,7 @@ fn main() -> Result<()> {
     let project_dir = path.join(&name);
     fs::create_dir(&project_dir)?;
 
-    for &(file_path, contents) in template_files::TEMPLATE_FILES.iter() {
+    for &(file_path, contents) in template_files.iter() {
         let mut file_path = file_path.to_string();
         if let Some(processed) = process_file(contents, &selected, &variables, &mut file_path) {
             let file_path = project_dir.join(file_path);
@@ -653,6 +704,17 @@ fn main() -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Extracts the chip specification from the BSP template's JSON files.
+///
+/// TODO: Read chip specification from JSON files in the template root.
+/// For now, returns a placeholder constant.
+fn get_chip_from_bsp_template(_template_files: &[(&str, &str)]) -> Chip {
+    // TODO: Parse JSON files in template root to find chip specification
+    // For now, return a placeholder - this will be implemented to read from
+    // BSP's template.yaml or a separate chip-spec.json file
+    Chip::Esp32c6
 }
 
 fn remove_incompatible_chip_options(chip: Chip, options: &mut Vec<GeneratorOptionItem>) {

--- a/src/template_embed.rs
+++ b/src/template_embed.rs
@@ -1,0 +1,87 @@
+/// Embeds template files from the `template/` directory into the binary.
+///
+/// Returns a static slice of tuples containing (relative_path, file_content).
+pub fn embed_templates() -> &'static [(&'static str, &'static str)] {
+    embed_templates_from_path(std::path::Path::new("template"))
+}
+
+/// Embeds template files from a custom directory path.
+///
+/// Returns a static slice of tuples containing (relative_path, file_content).
+pub fn embed_templates_from_path(
+    template_path: &std::path::Path,
+) -> &'static [(&'static str, &'static str)] {
+    let cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
+    let cwd_str = cwd.to_str().unwrap();
+
+    let mut files: Vec<(&'static str, &'static str)> = Vec::new();
+
+    for file in walkdir::WalkDir::new(template_path) {
+        let path = file.unwrap();
+
+        if !path.file_type().is_file() {
+            continue;
+        }
+
+        let path = path.path();
+
+        let canonical_path = path.canonicalize().unwrap();
+        let canonical_str = canonical_path.to_str().unwrap();
+
+        let relative_path = match canonical_str.strip_prefix(cwd_str) {
+            Some(r) => r.to_string(),
+            None => {
+                if template_path.is_absolute() {
+                    let template_base = template_path.canonicalize().unwrap();
+                    let template_base_str = template_base.to_str().unwrap();
+                    match canonical_str.strip_prefix(template_base_str) {
+                        Some(r) => r.to_string(),
+                        None => continue,
+                    }
+                } else {
+                    continue
+                }
+            }
+        }
+        .replace("\\", "/");
+
+        let relative_path = if relative_path.starts_with("/template/") {
+            relative_path.strip_prefix("/template/").unwrap().to_string()
+        } else if relative_path.starts_with('/') {
+            relative_path.strip_prefix('/').unwrap().to_string()
+        } else {
+            relative_path
+        };
+
+        if relative_path.starts_with("target/") {
+            continue;
+        }
+
+        let content = std::fs::read_to_string(path).unwrap();
+
+        // Leak the strings to make them 'static
+        let relative_path = Box::leak(relative_path.into_boxed_str());
+        let content = Box::leak(content.into_boxed_str());
+
+        files.push((relative_path, content));
+    }
+
+    Box::leak(files.into_boxed_slice())
+}
+
+pub fn generate_template_files_code() -> String {
+    let files = embed_templates();
+
+    let mut files_code = Vec::new();
+    for (file, content) in files.iter() {
+        files_code.push(quote::quote! { (#file, #content) })
+    }
+
+    let code = quote::quote! {
+        pub static TEMPLATE_FILES: &[(&str, &str)] = &[
+            #(#files_code),*
+        ];
+    };
+
+    code.to_string()
+}


### PR DESCRIPTION
This is a proposal PR open to discussion.

Adds a new --bsp (Board Support Package) CLI option that allows specifying
an external template directory. This enables using pre-configured
templates generated from esp-bsp JSON files, providing board-specific
pin locations and hardware information.

The feature supports:
  - Local directory paths (with tilde expansion for home directory)
  - Runtime template parsing when using external BSP

This is a prerequisite for implementing an esp-bsp style
board support ecosystem where templates can be versioned and shared
separately from the main esp-generate tool in separate git repository.

The idea is a tool to generate BSP templates from esp-bsp JSON files
and esp-generate base template will be created.

Remains to be solved:
  * chip selection should come from the BSP template
