### PR TITLE
Remove rust-analyzer.check.extraEnv

### DIFF
--- a/template/.helix/languages.toml
+++ b/template/.helix/languages.toml
@@ -13,7 +13,5 @@ cargo.allTargets = false
 cargo.target = "riscv32imac-unknown-none-elf"
 #IF option("xtensa")
 #REPLACE esp rust_toolchain
-check.extraEnv.RUSTUP_TOOLCHAIN = "esp"
-#REPLACE esp rust_toolchain
 cargo.extraEnv.RUSTUP_TOOLCHAIN = "esp"
 #ENDIF

--- a/template/.nvim.lua
+++ b/template/.nvim.lua
@@ -10,14 +10,12 @@ local rust_analyzer = {
 --IF option("xtensa")
 --REPLACE esp rust_toolchain
 rust_analyzer.cargo.extraEnv = { RUST_TOOLCHAIN = "esp" }
---REPLACE esp rust_toolchain
-rust_analyzer.check = { extraEnv = { RUST_TOOLCHAIN = "esp" } }
 rust_analyzer.server = { extraEnv = { RUST_TOOLCHAIN = "stable" } }
 --ENDIF
 
 -- Note the neovim name of the language server is rust_analyzer with an underscore.
 vim.lsp.config("rust_analyzer", {
     settings = {
-        ["rust-analyzer"] = rust_analyzer
+        ["rust-analyzer"] = rust_analyzer,
     },
 })

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -7,10 +7,6 @@
   "rust-analyzer.server.extraEnv": {
     "RUSTUP_TOOLCHAIN": "stable"
   },
-  "rust-analyzer.check.extraEnv": {
-    //REPLACE esp rust_toolchain
-    "RUSTUP_TOOLCHAIN": "esp"
-  },
   "rust-analyzer.cargo.extraEnv": {
     //REPLACE esp rust_toolchain
     "RUSTUP_TOOLCHAIN": "esp"

--- a/template/.zed/settings.json
+++ b/template/.zed/settings.json
@@ -20,12 +20,6 @@
                         "RUSTUP_TOOLCHAIN": "stable"
                     }
                 },
-                "check": {
-                    "extraEnv": {
-                        //REPLACE esp rust_toolchain
-                        "RUSTUP_TOOLCHAIN": "esp"
-                    }
-                }
                 //ENDIF
             }
         }


### PR DESCRIPTION
Remove `rust-analyzer.check.extraEnv` as it is redundant. `rust-analyzer.check.extraEnv` extends `rust-analyzer.cargo.extraEnv`, so defining it separately is unnecessary.

See also: <https://rust-analyzer.github.io/book/configuration.html#check.extraEnv>