### PR TITLE
Unselect options instead of preserving them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reverted: Preserve per-method flashing options when switching probe-rs and espflash (#327)
+- Flashing options are now cleared when selecting a different flashing method (#327)
+
 ### Fixed
 
 ### Removed

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,43 +25,6 @@ pub fn flatten_options(options: &[GeneratorOptionItem]) -> Vec<GeneratorOption> 
 }
 
 impl ActiveConfiguration {
-    fn option_requires(option: &GeneratorOption, requirement: &str) -> bool {
-        option.requires.iter().any(|r| r == requirement)
-    }
-
-    pub fn option_is_method_specific_for_state(
-        option: &GeneratorOption,
-        method_option: &str,
-        method_option_selected: bool,
-    ) -> bool {
-        if method_option_selected {
-            Self::option_requires(option, method_option)
-        } else {
-            let requirement = format!("!{method_option}");
-            Self::option_requires(option, &requirement)
-        }
-    }
-
-    pub fn can_switch_method_option(&self, method_option: &str) -> bool {
-        let mut has_selected_side = false;
-        let mut has_unselected_side = false;
-
-        let negated = format!("!{method_option}");
-        for option in &self.flat_options {
-            if Self::option_requires(option, method_option) {
-                has_selected_side = true;
-            }
-            if Self::option_requires(option, &negated) {
-                has_unselected_side = true;
-            }
-            if has_selected_side && has_unselected_side {
-                return true;
-            }
-        }
-
-        false
-    }
-
     pub fn is_group_selected(&self, group: &str) -> bool {
         self.selected
             .iter()
@@ -110,15 +73,191 @@ impl ActiveConfiguration {
         self.select_idx(index);
     }
 
+    /// Selects the option at `idx`.
+    ///
+    /// Negative requirements (`!X`) on this option force-deselect `X` if it's currently
+    /// selected. The deselection cascades: anything whose requirements are no longer
+    /// met is dropped as well (there is no save/restore mechanism; swapped-out options
+    /// simply disappear until the user re-enables them).
+    ///
+    /// Positive requirements remain hard gates — if any of them is unmet the call is
+    /// a no-op.
     pub fn select_idx(&mut self, idx: usize) {
-        let o = &self.flat_options[idx];
-        if !self.is_option_active(o) {
+        let o = self.flat_options[idx].clone();
+
+        // Positive requirements can't be materialised, so they still gate selection.
+        for req in &o.requires {
+            if req.starts_with('!') {
+                continue;
+            }
+            if self.is_selected(req) {
+                continue;
+            }
+            if Self::group_exists(req, &self.flat_options) && self.is_group_selected(req) {
+                continue;
+            }
             return;
         }
+
+        // Swap out same-group siblings (the existing "radio-button" behaviour).
         if !Self::deselect_group(&mut self.selected, &self.flat_options, &o.selection_group) {
             return;
         }
+
+        // Force-deselect anything directly forbidden by a `!X` requirement.
+        for req in &o.requires {
+            let Some(disables) = req.strip_prefix('!') else {
+                continue;
+            };
+            if let Some(pos) = self.selected_index(disables) {
+                self.selected.swap_remove(pos);
+            }
+        }
+
         self.selected.push(idx);
+
+        // Cascade: drop anything whose requirements broke as a side effect.
+        self.drop_unsatisfied();
+    }
+
+    /// Deselects the option at `idx`, then cascades: any remaining selection whose
+    /// requirements were propped up by the one we just removed is dropped too. This is
+    /// the counterpart to [`Self::select_idx`]'s cascade, and gives the user a
+    /// predictable "clear, don't save" experience when toggling off an option that
+    /// others depend on (e.g. toggling probe-rs off clears panic-rtt-target).
+    pub fn deselect_idx(&mut self, idx: usize) {
+        let Some(pos) = self.selected.iter().position(|&s| s == idx) else {
+            return;
+        };
+        self.selected.swap_remove(pos);
+        self.drop_unsatisfied();
+    }
+
+    /// Fixpoint loop that evicts selected options whose requirements are no longer
+    /// met. Used after cascading deselection.
+    fn drop_unsatisfied(&mut self) {
+        loop {
+            let victim = self.selected.iter().position(|&idx| {
+                let opt = &self.flat_options[idx];
+                !self.requirements_met(&opt.requires)
+            });
+            match victim {
+                Some(pos) => {
+                    self.selected.swap_remove(pos);
+                }
+                None => return,
+            }
+        }
+    }
+
+    /// Returns the names of currently-selected options that would be force-deselected
+    /// (directly or via cascade) if the user toggled the given option. Empty when
+    /// toggling would be non-destructive.
+    ///
+    /// Symmetric: works whether the option is currently selected (simulates deselect,
+    /// reports cascade) or not (simulates select, reports same-group siblings,
+    /// negative-requirement targets, and cascade). The option being toggled is never
+    /// itself reported — only collateral damage.
+    pub fn would_force_deselect(&self, option: &GeneratorOption) -> Vec<String> {
+        let option_idx = find_option(&option.name, &self.flat_options, self.chip).map(|(i, _)| i);
+
+        let mut simulated = self.selected.clone();
+        let currently_selected = option_idx
+            .map(|idx| simulated.contains(&idx))
+            .unwrap_or(false);
+
+        if currently_selected {
+            // Simulated deselect: remove the option, then let cascade evict dependents.
+            if let Some(idx) = option_idx {
+                if let Some(pos) = simulated.iter().position(|&i| i == idx) {
+                    simulated.swap_remove(pos);
+                }
+            }
+        } else {
+            // Simulated select: kick same-group siblings…
+            if !option.selection_group.is_empty() {
+                simulated.retain(|idx| {
+                    let o = &self.flat_options[*idx];
+                    o.selection_group != option.selection_group
+                });
+            }
+
+            // …and anything directly named by a `!X` requirement.
+            for req in &option.requires {
+                let Some(disables) = req.strip_prefix('!') else {
+                    continue;
+                };
+                if let Some(pos) = simulated
+                    .iter()
+                    .position(|&i| self.flat_options[i].name == disables)
+                {
+                    simulated.swap_remove(pos);
+                }
+            }
+
+            // Put the option into the simulated set so cascade evaluates it in context.
+            if let Some(idx) = option_idx {
+                if !simulated.contains(&idx) {
+                    simulated.push(idx);
+                }
+            }
+        }
+
+        // Shared cascade: drop anything whose requirements are no longer met.
+        loop {
+            let victim = simulated.iter().position(|&idx| {
+                let opt = &self.flat_options[idx];
+                !Self::requirements_met_against(opt, &simulated, &self.flat_options)
+            });
+            match victim {
+                Some(pos) => {
+                    simulated.swap_remove(pos);
+                }
+                None => break,
+            }
+        }
+
+        // Collateral = things that were selected but aren't in the simulated set
+        // (excluding the option itself, which is the user's direct action).
+        self.selected
+            .iter()
+            .copied()
+            .filter(|idx| !simulated.contains(idx) && Some(*idx) != option_idx)
+            .map(|idx| self.flat_options[idx].name.clone())
+            .collect()
+    }
+
+    /// Static helper: evaluate `option.requires` against an arbitrary selected set.
+    fn requirements_met_against(
+        option: &GeneratorOption,
+        selected: &[usize],
+        flat_options: &[GeneratorOption],
+    ) -> bool {
+        for requirement in &option.requires {
+            let (key, expected) = if let Some(rest) = requirement.strip_prefix('!') {
+                (rest, false)
+            } else {
+                (requirement.as_str(), true)
+            };
+
+            let is_selected = selected.iter().any(|s| flat_options[*s].name == key);
+            if is_selected == expected {
+                continue;
+            }
+
+            let is_group = flat_options.iter().any(|o| o.selection_group == key);
+            if is_group {
+                let group_selected = selected
+                    .iter()
+                    .any(|s| flat_options[*s].selection_group == key);
+                if group_selected == expected {
+                    continue;
+                }
+            }
+
+            return false;
+        }
+        true
     }
 
     /// Returns whether an item is active (can be selected).
@@ -178,32 +317,27 @@ impl ActiveConfiguration {
 
     /// Returns whether an option is active (can be selected).
     ///
-    /// This involves checking if the option is available for the current chip, if it's not
-    /// disabled by any other selected option, and if all its requirements are met.
+    /// An option is active when it is available for the current chip and all its
+    /// *positive* requirements are met. Negative requirements (`!X`) never block
+    /// selection — selecting the option will force-deselect `X` and anything that
+    /// cascades from that. Use [`Self::would_force_deselect`] to know what would be
+    /// evicted before committing.
     pub fn is_option_active(&self, option: &GeneratorOption) -> bool {
         if !option.chips.is_empty() && !option.chips.contains(&self.chip) {
             return false;
         }
 
-        // Are this option's requirements met?
-        if !self.requirements_met(&option.requires) {
-            return false;
-        }
-
-        // Does any of the enabled options have a requirement against this one?
-        for selected in self.selected.iter().copied() {
-            let Some(selected_option) = self.flat_options.get(selected) else {
-                ratatui::restore();
-                panic!("selected option not found: {selected}");
-            };
-
-            for requirement in selected_option.requires.iter() {
-                if let Some(requirement) = requirement.strip_prefix('!') {
-                    if requirement == option.name {
-                        return false;
-                    }
-                }
+        for req in &option.requires {
+            if req.starts_with('!') {
+                continue;
             }
+            if self.is_selected(req) {
+                continue;
+            }
+            if Self::group_exists(req, &self.flat_options) && self.is_group_selected(req) {
+                continue;
+            }
+            return false;
         }
 
         true
@@ -494,12 +628,15 @@ mod test {
     }
 
     #[test]
-    fn requiring_not_option_only_rejects_existing_group() {
+    fn negative_requirement_force_deselects_instead_of_blocking() {
+        // option2 requires `!option1`. option1 is selected. option2 must be *active*
+        // (negative requirements no longer block selection) and selecting it must
+        // clear option1 rather than save it somewhere for later.
         let options = vec![
             GeneratorOptionItem::Option(GeneratorOption {
                 name: "option1".to_string(),
                 display_name: "Foobar".to_string(),
-                selection_group: "group".to_string(),
+                selection_group: "".to_string(),
                 help: "".to_string(),
                 chips: vec![Chip::Esp32],
                 requires: vec![],
@@ -521,8 +658,112 @@ mod test {
         };
 
         active.select("option1");
-        let (_, opt2) = find_option("option2", &active.flat_options, Chip::Esp32).unwrap();
-        assert!(!active.is_option_active(opt2));
+        let opt2 = active.flat_options[1].clone();
+        assert!(active.is_option_active(&opt2));
+        assert_eq!(active.would_force_deselect(&opt2), vec!["option1".to_string()]);
+
+        active.select("option2");
+        assert!(active.is_selected("option2"));
+        assert!(!active.is_selected("option1"));
+    }
+
+    #[test]
+    fn select_cascade_evicts_dependents_of_deselected_option() {
+        // Real-world analogue: selecting `probe-rs` must clear `log` (which has
+        // `!probe-rs`) and `embedded-test` (which requires `log`). Nothing is
+        // remembered — if the user toggles probe-rs back off they start from
+        // scratch. Symmetrically, once probe-rs *is* selected, deselecting it must
+        // cascade out anything requiring it (here, `panic-rtt-target`) and the
+        // warning predicate must list those dependents.
+        let options = vec![
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "probe-rs".to_string(),
+                display_name: "probe-rs".to_string(),
+                selection_group: "".to_string(),
+                help: "".to_string(),
+                chips: vec![Chip::Esp32],
+                requires: vec![],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "log".to_string(),
+                display_name: "log".to_string(),
+                selection_group: "".to_string(),
+                help: "".to_string(),
+                chips: vec![Chip::Esp32],
+                requires: vec!["!probe-rs".to_string()],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "embedded-test".to_string(),
+                display_name: "embedded-test".to_string(),
+                selection_group: "".to_string(),
+                help: "".to_string(),
+                chips: vec![Chip::Esp32],
+                requires: vec!["log".to_string()],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "panic-rtt-target".to_string(),
+                display_name: "panic-rtt-target".to_string(),
+                selection_group: "".to_string(),
+                help: "".to_string(),
+                chips: vec![Chip::Esp32],
+                requires: vec!["probe-rs".to_string()],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "wifi".to_string(),
+                display_name: "wifi".to_string(),
+                selection_group: "".to_string(),
+                help: "".to_string(),
+                chips: vec![Chip::Esp32],
+                requires: vec![],
+            }),
+        ];
+        let mut active = ActiveConfiguration {
+            chip: Chip::Esp32,
+            selected: vec![],
+            flat_options: flatten_options(&options),
+            options,
+        };
+
+        active.select("log");
+        active.select("embedded-test");
+        active.select("wifi");
+
+        // Select side: hovering `probe-rs` while `log`/`embedded-test` are on
+        // reports both as going away; actually selecting it does the cascade.
+        let probe_rs = active.flat_options[0].clone();
+        let mut evicted = active.would_force_deselect(&probe_rs);
+        evicted.sort();
+        assert_eq!(
+            evicted,
+            vec!["embedded-test".to_string(), "log".to_string()]
+        );
+
+        active.select("probe-rs");
+        assert!(active.is_selected("probe-rs"));
+        assert!(!active.is_selected("log"));
+        assert!(!active.is_selected("embedded-test"));
+        assert!(active.is_selected("wifi"));
+
+        // Deselect side: with probe-rs on, add `panic-rtt-target` (requires
+        // probe-rs). Hovering probe-rs must now list panic-rtt-target in the
+        // warning; `deselect_idx` does the same cascade.
+        active.select("panic-rtt-target");
+        let probe_rs = active.flat_options[0].clone();
+        let mut evicted = active.would_force_deselect(&probe_rs);
+        evicted.sort();
+        assert_eq!(evicted, vec!["panic-rtt-target".to_string()]);
+        assert!(!evicted.contains(&"probe-rs".to_string())); // never itself
+        assert!(!evicted.contains(&"wifi".to_string())); // unrelated stays
+
+        let (probe_rs_flat_idx, _) =
+            find_option("probe-rs", &active.flat_options, Chip::Esp32).unwrap();
+        active.deselect_idx(probe_rs_flat_idx);
+        assert!(!active.is_selected("probe-rs"));
+        assert!(!active.is_selected("panic-rtt-target"));
+        // Previously-cleared `!probe-rs` options are NOT resurrected.
+        assert!(!active.is_selected("log"));
+        assert!(!active.is_selected("embedded-test"));
+        assert!(active.is_selected("wifi"));
     }
 
     fn empty() -> &'static [usize] {

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,6 +99,11 @@ impl ActiveConfiguration {
             return;
         }
 
+        // If the option is already selected, leave state as-is.
+        if self.selected.contains(&idx) {
+            return;
+        }
+
         // Swap out same-group siblings (the existing "radio-button" behaviour).
         if !Self::deselect_group(&mut self.selected, &self.flat_options, &o.selection_group) {
             return;
@@ -660,7 +665,10 @@ mod test {
         active.select("option1");
         let opt2 = active.flat_options[1].clone();
         assert!(active.is_option_active(&opt2));
-        assert_eq!(active.would_force_deselect(&opt2), vec!["option1".to_string()]);
+        assert_eq!(
+            active.would_force_deselect(&opt2),
+            vec!["option1".to_string()]
+        );
 
         active.select("option2");
         assert!(active.is_selected("option2"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -163,14 +163,26 @@ impl ActiveConfiguration {
     /// reports cascade) or not (simulates select, reports same-group siblings,
     /// negative-requirement targets, and cascade). The option being toggled is never
     /// itself reported — only collateral damage.
+    ///
+    /// Defensive short-circuit: if the option is currently unselected and cannot
+    /// actually be toggled on (chip-mismatch or an unmet *positive* requirement),
+    /// the toggle would be a no-op, so we return an empty list. We gate on
+    /// [`Self::is_option_toggleable`] rather than the strict [`Self::is_option_active`]
+    /// on purpose — a row whose only conflict is a negative requirement *is*
+    /// toggleable (selecting it cascades the conflict out), and its cascade is
+    /// exactly what callers want reported.
     pub fn would_force_deselect(&self, option: &GeneratorOption) -> Vec<String> {
         let option_idx = find_option(&option.name, &self.flat_options, self.chip).map(|(i, _)| i);
 
-        let mut simulated = self.selected.clone();
         let currently_selected = option_idx
-            .map(|idx| simulated.contains(&idx))
+            .map(|idx| self.selected.contains(&idx))
             .unwrap_or(false);
 
+        if !currently_selected && !self.is_option_toggleable(option) {
+            return Vec::new();
+        }
+
+        let mut simulated = self.selected.clone();
         if currently_selected {
             // Simulated deselect: remove the option, then let cascade evict dependents.
             if let Some(idx) = option_idx {
@@ -826,6 +838,86 @@ mod test {
         assert!(!active.is_selected("log"));
         assert!(!active.is_selected("embedded-test"));
         assert!(active.is_selected("wifi"));
+
+        // Short-circuit: an unselected option that isn't actually toggleable must
+        // report an empty cascade — toggling it is a no-op, so advertising
+        // collateral damage would be a lie.
+        //
+        // Fresh config (no prior selections) with three would-be-destructive
+        // rows whose toggle is *not* actionable:
+        //   * chip-mismatch (`chips = [Esp32c6]` on an Esp32 config),
+        //   * unmet positive requirement (`requires: ["missing"]`),
+        //   * both of the above.
+        // Each of them also carries `!victim`, which — without the guard —
+        // `would_force_deselect` would still happily report.
+        let options = vec![
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "victim".to_string(),
+                display_name: "victim".to_string(),
+                selection_group: "".to_string(),
+                help: "".to_string(),
+                chips: vec![Chip::Esp32],
+                requires: vec![],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "wrong-chip".to_string(),
+                display_name: "wrong-chip".to_string(),
+                selection_group: "".to_string(),
+                help: "".to_string(),
+                chips: vec![Chip::Esp32c6],
+                requires: vec!["!victim".to_string()],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "unmet-pos".to_string(),
+                display_name: "unmet-pos".to_string(),
+                selection_group: "".to_string(),
+                help: "".to_string(),
+                chips: vec![Chip::Esp32],
+                requires: vec!["missing".to_string(), "!victim".to_string()],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "neg-conflict".to_string(),
+                display_name: "neg-conflict".to_string(),
+                selection_group: "".to_string(),
+                help: "".to_string(),
+                chips: vec![Chip::Esp32],
+                requires: vec!["!victim".to_string()],
+            }),
+        ];
+        let mut active = ActiveConfiguration {
+            chip: Chip::Esp32,
+            selected: vec![],
+            flat_options: flatten_options(&options),
+            options,
+        };
+        active.select("victim");
+
+        let wrong_chip = active
+            .flat_options
+            .iter()
+            .find(|o| o.name == "wrong-chip")
+            .cloned()
+            .unwrap();
+        let unmet_pos = active
+            .flat_options
+            .iter()
+            .find(|o| o.name == "unmet-pos")
+            .cloned()
+            .unwrap();
+        let neg_conflict = active
+            .flat_options
+            .iter()
+            .find(|o| o.name == "neg-conflict")
+            .cloned()
+            .unwrap();
+
+        assert!(active.would_force_deselect(&wrong_chip).is_empty());
+        assert!(active.would_force_deselect(&unmet_pos).is_empty());
+        // Negative-only conflict is still actionable — the cascade must be reported.
+        assert_eq!(
+            active.would_force_deselect(&neg_conflict),
+            vec!["victim".to_string()]
+        );
     }
 
     fn empty() -> &'static [usize] {

--- a/src/config.rs
+++ b/src/config.rs
@@ -265,9 +265,16 @@ impl ActiveConfiguration {
         true
     }
 
-    /// Returns whether an item is active (can be selected).
+    /// Returns whether an item is toggleable in the UI.
     ///
-    /// This function is different from `is_option_active` in that it handles categories as well.
+    /// For a category, the category's own requirements must be met (strict) *and* at
+    /// least one descendant must itself be toggleable; for a leaf option this uses
+    /// [`Self::is_option_toggleable`], i.e. an option with an unmet `!X` is still
+    /// considered reachable because selecting it would cascade `X` out.
+    ///
+    /// This is the TUI-facing predicate. For strict validation (e.g. the CLI
+    /// checking whether a user's selection set is self-consistent), use
+    /// [`Self::is_option_active`] directly.
     pub fn is_active(&self, item: &GeneratorOptionItem) -> bool {
         match item {
             GeneratorOptionItem::Category(category) => {
@@ -281,7 +288,7 @@ impl ActiveConfiguration {
                 }
                 false
             }
-            GeneratorOptionItem::Option(option) => self.is_option_active(option),
+            GeneratorOptionItem::Option(option) => self.is_option_toggleable(option),
         }
     }
 
@@ -320,14 +327,58 @@ impl ActiveConfiguration {
         true
     }
 
-    /// Returns whether an option is active (can be selected).
+    /// Strict "is this option consistent with the current selection?" predicate.
     ///
-    /// An option is active when it is available for the current chip and all its
-    /// *positive* requirements are met. Negative requirements (`!X`) never block
-    /// selection — selecting the option will force-deselect `X` and anything that
-    /// cascades from that. Use [`Self::would_force_deselect`] to know what would be
-    /// evicted before committing.
+    /// Returns `true` only when:
+    ///   * the option is available for the current chip,
+    ///   * every one of its requirements is satisfied (including negative ones), and
+    ///   * no other currently-selected option has `!{option.name}` in its `requires`.
+    ///
+    /// This is the right check for validation: the CLI (`esp-generate --headless -o …`)
+    /// and the xtask regression harness rely on it to reject inconsistent selection
+    /// sets. It is *not* the right check for "can the user click this row in the TUI"
+    /// — that's [`Self::is_option_toggleable`], which permits negative-requirement
+    /// conflicts on the understanding that selecting the row will cascade them out
+    /// via [`Self::select_idx`].
     pub fn is_option_active(&self, option: &GeneratorOption) -> bool {
+        if !option.chips.is_empty() && !option.chips.contains(&self.chip) {
+            return false;
+        }
+
+        if !self.requirements_met(&option.requires) {
+            return false;
+        }
+
+        for selected in self.selected.iter().copied() {
+            let Some(selected_option) = self.flat_options.get(selected) else {
+                ratatui::restore();
+                panic!("selected option not found: {selected}");
+            };
+
+            for requirement in selected_option.requires.iter() {
+                if let Some(requirement) = requirement.strip_prefix('!') {
+                    if requirement == option.name {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Permissive "can the user toggle this row in the TUI?" predicate.
+    ///
+    /// Returns `true` when the option is available for the current chip and every
+    /// *positive* requirement is met. Negative requirements (`!X`) are intentionally
+    /// ignored here: the TUI treats them as force-deselect hints, not gates.
+    /// Selecting a row in this state routes through [`Self::select_idx`], which
+    /// cascades the negative-requirement targets (and their dependents) out; use
+    /// [`Self::would_force_deselect`] to preview that cascade.
+    ///
+    /// Callers that care about full self-consistency (CLI validation, xtask
+    /// coverage) must use [`Self::is_option_active`] instead.
+    pub fn is_option_toggleable(&self, option: &GeneratorOption) -> bool {
         if !option.chips.is_empty() && !option.chips.contains(&self.chip) {
             return false;
         }
@@ -664,7 +715,10 @@ mod test {
 
         active.select("option1");
         let opt2 = active.flat_options[1].clone();
-        assert!(active.is_option_active(&opt2));
+        // Strict validation (CLI/xtask): selection set is inconsistent → false.
+        assert!(!active.is_option_active(&opt2));
+        // TUI predicate: row is toggleable, selecting it will cascade `option1` out.
+        assert!(active.is_option_toggleable(&opt2));
         assert_eq!(
             active.would_force_deselect(&opt2),
             vec!["option1".to_string()]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use std::collections::HashMap;
 use std::io;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -41,8 +40,6 @@ pub fn setup_logger() -> Result<(), SetLoggerError> {
 pub struct Repository {
     pub config: ActiveConfiguration,
     path: Vec<usize>,
-    method_option_selected: HashMap<String, Vec<String>>,
-    method_option_unselected: HashMap<String, Vec<String>>,
 }
 
 impl Repository {
@@ -59,83 +56,7 @@ impl Repository {
                 options,
             },
             path: Vec::new(),
-            method_option_selected: HashMap::new(),
-            method_option_unselected: HashMap::new(),
         }
-    }
-
-    fn remember_method_selection(&mut self, method_option: &str, method_option_selected: bool) {
-        let snapshot: Vec<String> = self
-            .config
-            .selected
-            .iter()
-            .map(|idx| &self.config.flat_options[*idx])
-            .filter(|option| {
-                ActiveConfiguration::option_is_method_specific_for_state(
-                    option,
-                    method_option,
-                    method_option_selected,
-                )
-            })
-            .map(|option| option.name.clone())
-            .collect();
-
-        if method_option_selected {
-            self.method_option_selected
-                .insert(method_option.to_string(), snapshot);
-        } else {
-            self.method_option_unselected
-                .insert(method_option.to_string(), snapshot);
-        }
-    }
-
-    fn clear_method_specific_selection(
-        &mut self,
-        method_option: &str,
-        method_option_selected: bool,
-    ) {
-        self.config.selected.retain(|idx| {
-            let option = &self.config.flat_options[*idx];
-            !ActiveConfiguration::option_is_method_specific_for_state(
-                option,
-                method_option,
-                method_option_selected,
-            )
-        });
-    }
-
-    fn restore_method_selection(&mut self, method_option: &str, method_option_selected: bool) {
-        let to_restore = if method_option_selected {
-            self.method_option_selected
-                .get(method_option)
-                .cloned()
-                .unwrap_or_default()
-        } else {
-            self.method_option_unselected
-                .get(method_option)
-                .cloned()
-                .unwrap_or_default()
-        };
-
-        for option_name in to_restore {
-            self.config.select(&option_name);
-        }
-    }
-
-    fn switch_method_option(&mut self, method_option: &str) {
-        let currently_selected = self.config.is_selected(method_option);
-        self.remember_method_selection(method_option, currently_selected);
-        self.clear_method_specific_selection(method_option, currently_selected);
-
-        if currently_selected {
-            if let Some(i) = self.config.selected_index(method_option) {
-                self.config.selected.swap_remove(i);
-            }
-        } else {
-            self.config.select(method_option);
-        }
-
-        self.restore_method_selection(method_option, !currently_selected);
     }
 
     /// Returns the *explicitly* selected toolchain, if there is any
@@ -205,10 +126,7 @@ impl Repository {
     fn is_item_actionable(&self, item: &GeneratorOptionItem) -> bool {
         match item {
             GeneratorOptionItem::Category(_) => self.config.is_active(item),
-            GeneratorOptionItem::Option(option) => {
-                self.config.is_option_active(option)
-                    || self.config.can_switch_method_option(&option.name)
-            }
+            GeneratorOptionItem::Option(option) => self.config.is_option_active(option),
         }
     }
 
@@ -227,21 +145,16 @@ impl Repository {
         };
 
         let option_name = option.name.clone();
-        if self.config.can_switch_method_option(&option_name) {
-            self.switch_method_option(&option_name);
-            return;
-        }
 
-        let is_active = self.config.is_option_active(option);
-        if !is_active {
-            return;
-        }
-
-        if let Some(i) = self.config.selected_index(&option_name) {
-            if self.config.can_be_disabled(&option_name) {
-                self.config.selected.swap_remove(i);
-            }
-        } else {
+        if let Some(i) = self
+            .config
+            .selected
+            .iter()
+            .position(|s| self.config.flat_options[*s].name == option_name)
+        {
+            let idx = self.config.selected[i];
+            self.config.deselect_idx(idx);
+        } else if self.config.is_option_active(option) {
             self.config.select(&option_name);
         }
     }
@@ -254,42 +167,86 @@ impl Repository {
         self.path.pop();
     }
 
-    fn current_level_desc(&self, width: u16, style: &UiElements) -> Vec<(bool, String)> {
+    /// Builds the visible list rows.
+    ///
+    /// `hovered` is the index of the currently highlighted row (what the cursor is
+    /// on). Only that row gets the "will disable: …" warning trailer (styled yellow)
+    /// when a selection there would force-deselect something; every other row keeps
+    /// its normal right-aligned name. This keeps the list quiet and surfaces the
+    /// side-effect info only when the user is actually considering the action.
+    fn current_level_desc(
+        &self,
+        width: u16,
+        style: &UiElements,
+        hovered: Option<usize>,
+    ) -> Vec<(bool, Line<'static>)> {
         let level = self.current_level();
         let level_active = self.current_level_is_active();
 
         level
             .iter()
-            .map(|v| {
-                let name = if let GeneratorOptionItem::Option(_) = v {
-                    v.name()
-                } else {
-                    ""
-                };
-                let indicator = if self
+            .enumerate()
+            .map(|(idx, v)| {
+                let is_selected = self
                     .config
                     .selected
                     .iter()
                     .any(|o| self.config.flat_options[*o].name == v.name())
-                    && level_active
-                {
+                    && level_active;
+                let indicator = if is_selected {
                     style.selected
                 } else if v.is_category() {
                     style.category
                 } else {
                     style.unselected
                 };
+
+                // The option's internal name is always shown on the right; only the
+                // hovered row additionally appends a yellow " - will disable: …"
+                // clause when selecting it would force-deselect something. When the
+                // detailed list wouldn't fit, the clause degrades to
+                // " - will disable N" (count) before any actual truncation kicks in.
+                let name_part: String = match v {
+                    GeneratorOptionItem::Option(_) => v.name().to_string(),
+                    GeneratorOptionItem::Category(_) => String::new(),
+                };
+
                 // reserve indicator spacing; saturating_sub keeps padding non-negative so narrow widths don't overflow
                 let padding = (width as usize).saturating_sub(v.title().len() + 4);
+
+                let is_hovered = hovered == Some(idx);
+                // Symmetric: whether the row is selected or not, toggling it may
+                // force-deselect others — always ask the config what would happen.
+                let warning_part: Option<String> = match v {
+                    GeneratorOptionItem::Option(option) if is_hovered && level_active => {
+                        let evicted = self.config.would_force_deselect(option);
+                        if evicted.is_empty() {
+                            None
+                        } else {
+                            let detailed = format!(" - will disable: {}", evicted.join(", "));
+                            let budget = padding.saturating_sub(name_part.len());
+                            if detailed.len() <= budget {
+                                Some(detailed)
+                            } else {
+                                Some(format!(" - will disable {}", evicted.len()))
+                            }
+                        }
+                    }
+                    _ => None,
+                };
+
+                let trailer_len = name_part.len() + warning_part.as_deref().map_or(0, str::len);
+                let lead = format!(" {} {}", indicator, v.title());
+                let pad = " ".repeat(padding.saturating_sub(trailer_len));
+
+                let mut spans = vec![Span::raw(lead), Span::raw(pad), Span::raw(name_part)];
+                if let Some(warning) = warning_part {
+                    spans.push(Span::styled(warning, style.force_deselect_style));
+                }
+
                 (
                     level_active && self.is_item_actionable(v),
-                    format!(
-                        " {} {}{:>padding$}",
-                        indicator,
-                        v.title(),
-                        name,
-                        padding = padding,
-                    ),
+                    Line::from(spans),
                 )
             })
             .collect()
@@ -363,6 +320,8 @@ struct UiElements {
     selected: &'static str,
     unselected: &'static str,
     category: &'static str,
+    /// Style applied to the " - will disable …" hover clause.
+    force_deselect_style: Style,
 }
 
 struct Colors {
@@ -419,11 +378,13 @@ impl UiElements {
         selected: "✅",
         unselected: "  ",
         category: "▶️",
+        force_deselect_style: Style::new().fg(Color::Yellow),
     };
     const FALLBACK: Self = Self {
         selected: "*",
         unselected: " ",
         category: ">",
+        force_deselect_style: Style::new().fg(Color::Yellow),
     };
 }
 
@@ -523,12 +484,25 @@ mod test {
         })
     }
 
+    /// `UiElements` without any ratatui styling — keeps assertions about row text
+    /// simple and independent of the themes `FANCY` / `FALLBACK` use.
+    fn plain_ui() -> super::UiElements {
+        super::UiElements {
+            selected: "*",
+            unselected: " ",
+            category: ">",
+            force_deselect_style: ratatui::style::Style::new(),
+        }
+    }
+
     #[test]
-    fn switching_method_option_restores_previous_method_specific_selections() {
+    fn toggling_method_clears_other_side_without_restoring_on_toggle_back() {
+        // Mirrors the espflash ↔ probe-rs scenario: selecting `method` kicks out all
+        // options that depend on `!method`. Toggling `method` back off must NOT
+        // resurrect them — the old save/restore behaviour is gone on purpose.
         let options = vec![
             option("method", &[]),
             option("method-selected-a", &["method"]),
-            option("method-selected-b", &["method"]),
             option("method-unselected-a", &["!method"]),
             option("method-unselected-b", &["!method"]),
             option("defmt", &[]),
@@ -538,47 +512,164 @@ mod test {
             Chip::Esp32,
             options,
             &[
-                "method".to_string(),
-                "method-selected-a".to_string(),
+                "method-unselected-a".to_string(),
+                "method-unselected-b".to_string(),
                 "defmt".to_string(),
             ],
         );
 
-        repository.switch_method_option("method");
+        repository.toggle_current(0);
+        assert!(repository.config.is_selected("method"));
+        assert!(!repository.config.is_selected("method-unselected-a"));
+        assert!(!repository.config.is_selected("method-unselected-b"));
+        assert!(repository.config.is_selected("defmt"));
+
+        repository.config.select("method-selected-a");
+
+        repository.toggle_current(0);
         assert!(!repository.config.is_selected("method"));
         assert!(!repository.config.is_selected("method-selected-a"));
-        assert!(repository.config.is_selected("defmt"));
-
-        repository.config.select("method-unselected-a");
-        repository.switch_method_option("method");
-        assert!(repository.config.is_selected("method"));
-        assert!(repository.config.is_selected("method-selected-a"));
+        // None of the previously-cleared `!method` options come back.
         assert!(!repository.config.is_selected("method-unselected-a"));
+        assert!(!repository.config.is_selected("method-unselected-b"));
         assert!(repository.config.is_selected("defmt"));
-
-        repository.switch_method_option("method");
-        assert!(!repository.config.is_selected("method"));
-        assert!(repository.config.is_selected("method-unselected-a"));
     }
 
     #[test]
-    fn switching_back_without_new_intermediate_selections_restores_previous_side() {
+    fn force_deselect_trailer_appears_only_on_hovered_row() {
+        // The "will disable …" trailer must:
+        //  * only show on the hovered row (keeps the list quiet),
+        //  * live in its own span so the theme can style it,
+        //  * appear for BOTH directions — selecting a row that force-deselects
+        //    others, and deselecting a selected row whose dependents cascade.
         let options = vec![
             option("method", &[]),
-            option("method-selected-a", &["method"]),
             option("method-unselected-a", &["!method"]),
+            option("dependent", &["method"]),
         ];
 
-        let mut repository =
-            Repository::new(Chip::Esp32, options, &["method-unselected-a".to_string()]);
+        let repository = Repository::new(
+            Chip::Esp32,
+            options,
+            &[
+                "method".to_string(),
+                "dependent".to_string(),
+            ],
+        );
 
-        repository.toggle_current(0);
-        assert!(repository.config.is_selected("method"));
-        assert!(!repository.config.is_selected("method-unselected-a"));
+        let ui = plain_ui();
 
-        repository.toggle_current(0);
-        assert!(!repository.config.is_selected("method"));
-        assert!(repository.config.is_selected("method-unselected-a"));
+        let row_text = |idx: usize, hover: Option<usize>| -> String {
+            repository
+                .current_level_desc(80, &ui, hover)
+                .into_iter()
+                .nth(idx)
+                .map(|(_, line)| {
+                    line.spans
+                        .iter()
+                        .map(|s| s.content.to_string())
+                        .collect::<String>()
+                })
+                .unwrap()
+        };
+
+        // Deselect-side: hovering the already-selected `method` warns that
+        // toggling it off would cascade out `dependent`.
+        let method_hover = row_text(0, Some(0));
+        assert!(
+            method_hover.contains("method")
+                && method_hover.contains("- will disable: dependent"),
+            "expected deselect-side warning on selected hovered row, got: {method_hover:?}"
+        );
+
+        // Select-side: hovering unselected `method-unselected-a` warns that
+        // selecting it would kick out `method` (and, via cascade, `dependent`).
+        let unselected_hover = row_text(1, Some(1));
+        assert!(
+            unselected_hover.contains("method-unselected-a")
+                && unselected_hover.contains("- will disable:")
+                && unselected_hover.contains("method")
+                && unselected_hover.contains("dependent"),
+            "expected select-side warning on hovered row, got: {unselected_hover:?}"
+        );
+
+        // The warning must live in its own span (so the theme can style it) and
+        // must not include the option name that was printed before it.
+        let hover_line = repository
+            .current_level_desc(80, &ui, Some(1))
+            .into_iter()
+            .nth(1)
+            .map(|(_, line)| line)
+            .unwrap();
+        let warning_span = hover_line
+            .spans
+            .iter()
+            .find(|s| s.content.contains("will disable"))
+            .expect("warning span");
+        assert!(!warning_span.content.contains("method-unselected-a "));
+
+        // Hovering a row whose toggle is non-destructive means nothing on any
+        // row can carry the warning.
+        for idx in 0..3 {
+            let text = row_text(idx, Some(2 /* `dependent` — non-destructive */));
+            assert!(
+                !text.contains("will disable"),
+                "no row must show the warning when hover is non-destructive, got: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn force_deselect_trailer_collapses_to_count_when_too_wide() {
+        // With several long-named options being evicted and a narrow row, the
+        // detailed list must collapse to "will disable N" rather than overflow /
+        // truncate the text.
+        let options = vec![
+            option("m", &[]),
+            option("loooooong-one", &["!m"]),
+            option("loooooong-two", &["!m"]),
+            option("loooooong-three", &["!m"]),
+        ];
+
+        let repository = Repository::new(
+            Chip::Esp32,
+            options,
+            &[
+                "loooooong-one".to_string(),
+                "loooooong-two".to_string(),
+                "loooooong-three".to_string(),
+            ],
+        );
+
+        let ui = plain_ui();
+
+        // Narrow width — the detailed trailer won't fit.
+        let narrow = repository
+            .current_level_desc(40, &ui, Some(0))
+            .into_iter()
+            .map(|(_, line)| line)
+            .collect::<Vec<_>>();
+        let narrow_text: String = narrow[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            narrow_text.contains("will disable 3"),
+            "expected count fallback, got: {narrow_text:?}"
+        );
+        assert!(
+            !narrow_text.contains("will disable:"),
+            "detailed list must not be present when it doesn't fit, got: {narrow_text:?}"
+        );
+
+        // Wide enough — the detailed list must be shown.
+        let wide = repository
+            .current_level_desc(200, &ui, Some(0))
+            .into_iter()
+            .map(|(_, line)| line)
+            .collect::<Vec<_>>();
+        let wide_text: String = wide[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            wide_text.contains("will disable: loooooong-one, loooooong-two, loooooong-three"),
+            "expected detailed trailer, got: {wide_text:?}"
+        );
     }
 }
 
@@ -709,13 +800,17 @@ impl App {
         // We can render the header in outer_area.
         outer_block.render(outer_area, buf);
 
-        // Iterate through all elements in the `items` and stylize them.
+        // The hovered index is what ratatui's ListState reports as selected; rows
+        // build their "will disable …" trailer only for this row so the list stays
+        // quiet otherwise.
+        let hovered = self.state.last().and_then(|s| s.selected());
+
         let items: Vec<ListItem> = self
             .repository
-            .current_level_desc(area.width, &self.ui_elements)
+            .current_level_desc(area.width, &self.ui_elements, hovered)
             .into_iter()
-            .map(|(enabled, value)| {
-                ListItem::new(value).style(if enabled {
+            .map(|(enabled, line)| {
+                ListItem::new(line).style(if enabled {
                     Style::default()
                 } else {
                     Style::default().fg(self.colors.disabled_style_fg)
@@ -762,30 +857,21 @@ impl App {
             .min(self.repository.current_level().len() - 1);
         let option = &self.repository.current_level()[selected];
 
-        let mut relationships = self.repository.config.collect_relationships(option);
+        let relationships = self.repository.config.collect_relationships(option);
 
-        if let GeneratorOptionItem::Option(option) = option {
-            // Switchable method options are actionable even with opposite-side selections,
-            // so showing `Disabled by` here would be misleading.
-            if self
-                .repository
-                .config
-                .can_switch_method_option(&option.name)
-            {
-                relationships.disabled_by.clear();
-            }
-        }
-
+        // `disabled_by` used to explain why an option could not be toggled; now that
+        // every option with its positive requirements satisfied is selectable (and the
+        // right-side row trailer lists what a selection would kick out), surfacing it
+        // here would be redundant and confusing.
         let Relationships {
             requires,
             required_by,
-            disabled_by,
+            disabled_by: _,
         } = relationships;
 
         let help_text = option.help();
         let help_text = append_list_as_sentence(help_text, "Requires", &requires);
         let help_text = append_list_as_sentence(&help_text, "Required by", &required_by);
-        let help_text = append_list_as_sentence(&help_text, "Disabled by", &disabled_by);
 
         if help_text.is_empty() {
             return None;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -218,10 +218,17 @@ impl Repository {
                 let padding = (width as usize).saturating_sub(v.title().len() + 4);
 
                 let is_hovered = hovered == Some(idx);
+                let is_actionable = self.is_item_actionable(v);
                 // Symmetric: whether the row is selected or not, toggling it may
                 // force-deselect others — always ask the config what would happen.
+                // Gated on `is_actionable` so rows the user can't actually toggle
+                // (chip-mismatch or unmet positive requirements) don't advertise a
+                // phantom cascade. Rows with only a negative-requirement conflict
+                // remain actionable (that's the whole point of the warning).
                 let warning_part: Option<String> = match v {
-                    GeneratorOptionItem::Option(option) if is_hovered && level_active => {
+                    GeneratorOptionItem::Option(option)
+                        if is_hovered && level_active && is_actionable =>
+                    {
                         let evicted = self.config.would_force_deselect(option);
                         if evicted.is_empty() {
                             None
@@ -247,10 +254,7 @@ impl Repository {
                     spans.push(Span::styled(warning, style.force_deselect_style));
                 }
 
-                (
-                    level_active && self.is_item_actionable(v),
-                    Line::from(spans),
-                )
+                (level_active && is_actionable, Line::from(spans))
             })
             .collect()
     }
@@ -487,6 +491,17 @@ mod test {
         })
     }
 
+    fn option_for_chips(name: &str, requires: &[&str], chips: &[Chip]) -> GeneratorOptionItem {
+        GeneratorOptionItem::Option(GeneratorOption {
+            name: name.to_string(),
+            display_name: name.to_string(),
+            selection_group: String::new(),
+            help: String::new(),
+            requires: requires.iter().map(|r| r.to_string()).collect(),
+            chips: chips.to_vec(),
+        })
+    }
+
     /// `UiElements` without any ratatui styling — keeps assertions about row text
     /// simple and independent of the themes `FANCY` / `FALLBACK` use.
     fn plain_ui() -> super::UiElements {
@@ -618,6 +633,44 @@ mod test {
             assert!(
                 !text.contains("will disable"),
                 "no row must show the warning when hover is non-destructive, got: {text:?}"
+            );
+        }
+
+        // Non-toggleable rows must stay silent even when `would_force_deselect`
+        // would otherwise report evictions — a user can't actually toggle the
+        // row, so advertising a phantom cascade is misleading.
+        //
+        // Two shapes are exercised:
+        //   * `unmet-pos`  — positive requirement not satisfied (`needs-x`).
+        //   * `wrong-chip` — chip-mismatch; `requires: ["!method"]` would still
+        //     return a cascade from the raw predicate, so only the gate keeps
+        //     the row quiet.
+        let options = vec![
+            option("method", &[]),
+            option("unmet-pos", &["needs-x", "!method"]),
+            option_for_chips("wrong-chip", &["!method"], &[Chip::Esp32c6]),
+        ];
+        let repository =
+            Repository::new(Chip::Esp32, options, &["method".to_string()]);
+
+        for idx in 1..=2 {
+            let (actionable, line) = repository
+                .current_level_desc(80, &ui, Some(idx))
+                .into_iter()
+                .nth(idx)
+                .unwrap();
+            let text: String = line
+                .spans
+                .iter()
+                .map(|s| s.content.to_string())
+                .collect();
+            assert!(
+                !actionable,
+                "row {idx} must report as non-actionable, got: {text:?}"
+            );
+            assert!(
+                !text.contains("will disable"),
+                "non-toggleable hovered row {idx} must not show the warning, got: {text:?}"
             );
         }
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -126,7 +126,10 @@ impl Repository {
     fn is_item_actionable(&self, item: &GeneratorOptionItem) -> bool {
         match item {
             GeneratorOptionItem::Category(_) => self.config.is_active(item),
-            GeneratorOptionItem::Option(option) => self.config.is_option_active(option),
+            // Permissive: negative-requirement conflicts are treated as force-deselect
+            // hints, not gates. `toggle_current` routes through `select_idx`, which
+            // cascades them out.
+            GeneratorOptionItem::Option(option) => self.config.is_option_toggleable(option),
         }
     }
 
@@ -154,7 +157,7 @@ impl Repository {
         {
             let idx = self.config.selected[i];
             self.config.deselect_idx(idx);
-        } else if self.config.is_option_active(option) {
+        } else if self.config.is_option_toggleable(option) {
             self.config.select(&option_name);
         }
     }


### PR DESCRIPTION
This PR replaces the logic to remember options with a visual indicator that lists what will be cleared.