### PR TITLE
Move chip selection to the TUI

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Generate a sample project
         run: |
-          cargo run --release --quiet --no-default-features -- --headless --chip=esp32c6 --output-path=. test-project
+          cargo run --release --quiet --no-default-features -- --headless --output-path=. -o esp32c6 test-project
 
       - name: Check links in generated project
         uses: lycheeverse/lychee-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Chip selector has been moved to the TUI. (#328)
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Chip selector has been moved to the TUI. (#328)
+- The chip needs to be specified as `-o <chip>` instead of `--chip <chip>` when using CLI (#328)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ update-informer = { version = "1.3.0", optional = true }
 serde           = { version = "1.0.228", features = ["derive"] }
 serde_yaml      = "0.9.33"
 toml_edit       = "0.25.11+spec-1.1.0"
-indexmap = "2.13.0"
+indexmap = { version = "2.13.0", features = ["serde"] }
 
 [build-dependencies]
 quote   = "1.0.45"

--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ You can also directly download pre-compiled [release binaries] or use [`cargo-bi
       ```
       esp-generate
       ```
-      You will be prompted to select a target chip and name for your project, after which you would use TUI to select the other options you need for your project.
+      You will be prompted for a project name, and the target chip (along with every other option) is selected inside the TUI.
 
    2. Using the Command Line Interface (CLI), adding the options to the `esp-generate` command:
 
       ```
-      esp-generate --chip esp32 -o alloc -o wifi your-project
+      esp-generate -o esp32 -o alloc -o wifi your-project
       ```
       Use the `--headless` flag to avoid using the TUI.
 
-      Replace the chip and project name accordingly, and select the desired options using the `-o/--option` flag.
-      Use the `esp-generate list-options` command to see a list of available options. Use `esp-generate explain <option>` to get a detailed explanation of an option.
+      Replace the chip and project name accordingly. The target chip (e.g. `esp32c6`) is just one of the available `-o/--option` values.
+      Use the `esp-generate list-options` command to see a list of available options (chips included). Use `esp-generate explain <option>` to get a detailed explanation of an option.
 
 [release binaries]: https://github.com/esp-rs/esp-generate/releases
 [`cargo-binstall`]: https://github.com/cargo-bins/cargo-binstall

--- a/src/chip_selector.rs
+++ b/src/chip_selector.rs
@@ -15,7 +15,7 @@ use strum::IntoEnumIterator;
 ///
 /// The entries' `name` is `chip.to_string()` (e.g. `esp32c6`), which matches
 /// what `#IF option("esp32c6")` in template files expects and what
-/// `remove_incompatible_chip_options` compares against.
+/// `compatible: { chip: [...] }` allow-lists compare against.
 pub fn populate_chip_category(options: &mut [GeneratorOptionItem]) {
     for item in options.iter_mut() {
         let GeneratorOptionItem::Category(category) = item else {
@@ -48,6 +48,7 @@ pub fn populate_chip_category(options: &mut [GeneratorOptionItem]) {
 mod test {
     use super::*;
     use esp_generate::template::{GeneratorOption, GeneratorOptionCategory};
+    use indexmap::IndexMap;
 
     fn placeholder_tree() -> Vec<GeneratorOptionItem> {
         vec![GeneratorOptionItem::Category(GeneratorOptionCategory {
@@ -61,7 +62,7 @@ mod test {
                 selection_group: "chip".to_string(),
                 help: String::new(),
                 requires: Vec::new(),
-                chips: Vec::new(),
+                compatible: IndexMap::new(),
             })],
         })]
     }
@@ -92,7 +93,7 @@ mod test {
             };
             assert_eq!(o.selection_group, "chip");
             assert!(
-                o.chips.is_empty(),
+                !o.compatible.contains_key("chip"),
                 "chip-group options must not restrict themselves by chip (they drive the restriction)"
             );
         }

--- a/src/chip_selector.rs
+++ b/src/chip_selector.rs
@@ -1,0 +1,127 @@
+use esp_generate::Chip;
+use esp_generate::template::GeneratorOptionItem;
+use strum::IntoEnumIterator;
+
+/// Populates the `chip` category in the template options with one entry per
+/// supported [`Chip`], all sharing the `chip` selection group so only one can
+/// be active at a time.
+///
+/// This mirrors [`esp_generate::modules::populate_module_category`] and
+/// [`crate::toolchain::ToolchainCategory::populate`]: a single `PLACEHOLDER`
+/// `!Option` in the YAML is replaced with the real set on every build.
+/// `build_options_for_chip` re-runs this on every chip switch, so the populate
+/// step must stay idempotent — meaning it operates on a fresh template clone
+/// and doesn't care about any previous state of the category.
+///
+/// The entries' `name` is `chip.to_string()` (e.g. `esp32c6`), which matches
+/// what `#IF option("esp32c6")` in template files expects and what
+/// `remove_incompatible_chip_options` compares against.
+pub fn populate_chip_category(options: &mut [GeneratorOptionItem]) {
+    for item in options.iter_mut() {
+        let GeneratorOptionItem::Category(category) = item else {
+            continue;
+        };
+        if category.name != "chip" {
+            continue;
+        }
+
+        let template_opt = match category.options.first() {
+            Some(GeneratorOptionItem::Option(opt)) => opt.clone(),
+            _ => panic!("chip category must contain a placeholder !Option"),
+        };
+
+        category.options.clear();
+
+        for chip in Chip::iter() {
+            let mut opt = template_opt.clone();
+            opt.name = chip.to_string();
+            opt.display_name = chip.to_string();
+            opt.selection_group = "chip".to_string();
+            category.options.push(GeneratorOptionItem::Option(opt));
+        }
+
+        break;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use esp_generate::template::{GeneratorOption, GeneratorOptionCategory};
+
+    fn placeholder_tree() -> Vec<GeneratorOptionItem> {
+        vec![GeneratorOptionItem::Category(GeneratorOptionCategory {
+            name: "chip".to_string(),
+            display_name: "Chip".to_string(),
+            help: String::new(),
+            requires: Vec::new(),
+            options: vec![GeneratorOptionItem::Option(GeneratorOption {
+                name: "PLACEHOLDER".to_string(),
+                display_name: "<dynamic>".to_string(),
+                selection_group: "chip".to_string(),
+                help: String::new(),
+                requires: Vec::new(),
+                chips: Vec::new(),
+            })],
+        })]
+    }
+
+    #[test]
+    fn populate_expands_placeholder_into_one_option_per_chip() {
+        let mut tree = placeholder_tree();
+        populate_chip_category(&mut tree);
+
+        let GeneratorOptionItem::Category(category) = &tree[0] else {
+            panic!("expected category");
+        };
+
+        let expected: Vec<String> = Chip::iter().map(|c| c.to_string()).collect();
+        let actual: Vec<String> = category
+            .options
+            .iter()
+            .map(|item| match item {
+                GeneratorOptionItem::Option(o) => o.name.clone(),
+                _ => panic!("chip category must only hold options"),
+            })
+            .collect();
+        assert_eq!(actual, expected);
+
+        for item in &category.options {
+            let GeneratorOptionItem::Option(o) = item else {
+                unreachable!();
+            };
+            assert_eq!(o.selection_group, "chip");
+            assert!(
+                o.chips.is_empty(),
+                "chip-group options must not restrict themselves by chip (they drive the restriction)"
+            );
+        }
+    }
+
+    #[test]
+    fn populate_is_idempotent() {
+        // Matters because `build_options_for_chip` runs this on every chip
+        // switch against a fresh clone — but tests (and any future caller
+        // that reuses a tree) must not see the list grow across repeated
+        // populations. Here we emulate that by priming with the placeholder
+        // and invoking populate twice.
+        let mut tree = placeholder_tree();
+        populate_chip_category(&mut tree);
+        let first_len = match &tree[0] {
+            GeneratorOptionItem::Category(c) => c.options.len(),
+            _ => unreachable!(),
+        };
+
+        // Second population needs a tree that still starts with a valid
+        // first option — `populate` uses `options.first()` as its template.
+        // After the first call, the first option is a real chip option with
+        // `selection_group = "chip"`, which is fine to clone from.
+        populate_chip_category(&mut tree);
+        let second_len = match &tree[0] {
+            GeneratorOptionItem::Category(c) => c.options.len(),
+            _ => unreachable!(),
+        };
+
+        assert_eq!(first_len, second_len);
+    }
+}

--- a/src/chip_selector.rs
+++ b/src/chip_selector.rs
@@ -1,6 +1,7 @@
-use esp_generate::Chip;
-use esp_generate::template::GeneratorOptionItem;
 use strum::IntoEnumIterator;
+
+use crate::Chip;
+use crate::template::GeneratorOptionItem;
 
 /// Populates the `chip` category in the template options with one entry per
 /// supported [`Chip`], all sharing the `chip` selection group so only one can
@@ -47,7 +48,7 @@ pub fn populate_chip_category(options: &mut [GeneratorOptionItem]) {
 #[cfg(test)]
 mod test {
     use super::*;
-    use esp_generate::template::{GeneratorOption, GeneratorOptionCategory};
+    use crate::template::{GeneratorOption, GeneratorOptionCategory};
     use indexmap::IndexMap;
 
     fn placeholder_tree() -> Vec<GeneratorOptionItem> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,31 @@ impl ActiveConfiguration {
             .collect();
     }
 
+    /// Swap in a new chip + options tree and keep `selected` / `flat_options`
+    /// consistent.
+    ///
+    /// This is the supported entry point for dynamic chip switching: the caller
+    /// builds the new options tree (chip filter + module population + toolchain
+    /// population) off of the pristine template and hands it over. The rest is
+    /// mechanical:
+    ///   * [`Self::rebuild_indices`] remaps selection indices by option name,
+    ///     silently dropping any name that no longer exists in the new tree;
+    ///   * [`Self::drop_unsatisfied`] then cascades out anything whose
+    ///     requirements are no longer met against the trimmed set (e.g. an
+    ///     option that survived by name but depended on something the chip
+    ///     switch eliminated).
+    ///
+    /// Note: `path` on [`crate::tui::Repository`] is a UI concern and is NOT
+    /// touched here. Callers that change the chip should also either reset or
+    /// clamp the menu path themselves — the category the user was browsing may
+    /// no longer exist.
+    pub fn reset_options(&mut self, chip: Chip, options: Vec<GeneratorOptionItem>) {
+        self.chip = chip;
+        self.options = options;
+        self.rebuild_indices();
+        self.drop_unsatisfied();
+    }
+
     pub fn is_group_selected(&self, group: &str) -> bool {
         self.selected
             .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,34 @@ pub fn flatten_options(options: &[GeneratorOptionItem]) -> Vec<GeneratorOption> 
 }
 
 impl ActiveConfiguration {
+    /// Rebuild [`Self::flat_options`] from [`Self::options`] and remap
+    /// [`Self::selected`] by option name.
+    ///
+    /// Must be called whenever `options` is mutated out-of-band — e.g. after
+    /// the toolchain category is (re)populated in response to a scan result or
+    /// a chip switch. `selected` stores indices into `flat_options`, so any
+    /// structural change to the tree invalidates them.
+    ///
+    /// Options whose name is no longer present in the rebuilt flat view are
+    /// silently dropped from `selected`. This is the correct behaviour for a
+    /// chip switch that removes toolchains (or any other category items): the
+    /// cascade logic in `select_idx` / `deselect_idx` runs off indices, not
+    /// names, so leaving dangling indices would be a latent panic.
+    pub fn rebuild_indices(&mut self) {
+        let selected_names: Vec<String> = self
+            .selected
+            .iter()
+            .filter_map(|&idx| self.flat_options.get(idx).map(|o| o.name.clone()))
+            .collect();
+
+        self.flat_options = flatten_options(&self.options);
+
+        self.selected = selected_names
+            .into_iter()
+            .filter_map(|name| self.flat_options.iter().position(|o| o.name == name))
+            .collect();
+    }
+
     pub fn is_group_selected(&self, group: &str) -> bool {
         self.selected
             .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -265,6 +265,23 @@ impl ActiveConfiguration {
                 }
             }
 
+            // Chip-switch preview: if the option being toggled is in the
+            // `chip` selection group, every currently-selected option whose
+            // `chips` filter excludes the new chip would be removed from
+            // the tree outright by `remove_incompatible_chip_options` during
+            // the rebuild. From the user's perspective that's
+            // indistinguishable from a force-deselect, so we report it here
+            // too. Options with an empty `chips` field are chip-agnostic and
+            // stay.
+            if option.selection_group == "chip"
+                && let Ok(target_chip) = option.name.parse::<Chip>()
+            {
+                simulated.retain(|idx| {
+                    let o = &self.flat_options[*idx];
+                    o.chips.is_empty() || o.chips.contains(&target_chip)
+                });
+            }
+
             // Put the option into the simulated set so cascade evaluates it in context.
             if let Some(idx) = option_idx {
                 if !simulated.contains(&idx) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -192,12 +192,19 @@ impl ActiveConfiguration {
     }
 
     /// Fixpoint loop that evicts selected options whose requirements are no longer
-    /// met. Used after cascading deselection.
+    /// met, or whose `compatible` constraint is no longer satisfied. Used after
+    /// cascading deselection and after any chip / selection-group change that
+    /// might have invalidated compatibility.
     fn drop_unsatisfied(&mut self) {
         loop {
             let victim = self.selected.iter().position(|&idx| {
                 let opt = &self.flat_options[idx];
                 !self.requirements_met(&opt.requires)
+                    || !Self::is_option_compatible_against(
+                        opt,
+                        &self.selected,
+                        &self.flat_options,
+                    )
             });
             match victim {
                 Some(pos) => {
@@ -265,23 +272,6 @@ impl ActiveConfiguration {
                 }
             }
 
-            // Chip-switch preview: if the option being toggled is in the
-            // `chip` selection group, every currently-selected option whose
-            // `chips` filter excludes the new chip would be removed from
-            // the tree outright by `remove_incompatible_chip_options` during
-            // the rebuild. From the user's perspective that's
-            // indistinguishable from a force-deselect, so we report it here
-            // too. Options with an empty `chips` field are chip-agnostic and
-            // stay.
-            if option.selection_group == "chip"
-                && let Ok(target_chip) = option.name.parse::<Chip>()
-            {
-                simulated.retain(|idx| {
-                    let o = &self.flat_options[*idx];
-                    o.chips.is_empty() || o.chips.contains(&target_chip)
-                });
-            }
-
             // Put the option into the simulated set so cascade evaluates it in context.
             if let Some(idx) = option_idx {
                 if !simulated.contains(&idx) {
@@ -290,11 +280,18 @@ impl ActiveConfiguration {
             }
         }
 
-        // Shared cascade: drop anything whose requirements are no longer met.
+        // Shared cascade: drop anything whose requirements are no longer met
+        // or whose `compatible` constraint is no longer satisfied. The latter
+        // is how chip-switch previews show every option that would be pruned
+        // by the new chip — no chip-specific code path needed, since the chip
+        // is just another entry in the `chip` selection group and any option
+        // with `compatible: {chip: [...]}` simply drops out of the simulated
+        // set when the new chip isn't in its allow-list.
         loop {
             let victim = simulated.iter().position(|&idx| {
                 let opt = &self.flat_options[idx];
                 !Self::requirements_met_against(opt, &simulated, &self.flat_options)
+                    || !Self::is_option_compatible_against(opt, &simulated, &self.flat_options)
             });
             match victim {
                 Some(pos) => {
@@ -409,10 +406,44 @@ impl ActiveConfiguration {
         true
     }
 
+    /// Returns whether every `compatible: { group: [...] }` entry on `option`
+    /// is currently satisfied. Absent groups (and the empty map) are trivially
+    /// compatible. For each listed group there must be a selected option whose
+    /// `selection_group` matches the key AND whose `name` is in the allow-list.
+    ///
+    /// This is the generalised replacement for the old `chips:` filter —
+    /// `compatible: { chip: [...] }` is now how a template option expresses
+    /// "I only apply to these chips", driven by the current selection in the
+    /// `chip` selection group.
+    pub fn is_option_compatible(&self, option: &GeneratorOption) -> bool {
+        Self::is_option_compatible_against(option, &self.selected, &self.flat_options)
+    }
+
+    /// Static variant of [`Self::is_option_compatible`] that evaluates against
+    /// an arbitrary selection set. Used by [`Self::would_force_deselect`] to
+    /// simulate the effect of a toggle without mutating `self`.
+    fn is_option_compatible_against(
+        option: &GeneratorOption,
+        selected: &[usize],
+        flat_options: &[GeneratorOption],
+    ) -> bool {
+        for (group, allowed) in &option.compatible {
+            let group_ok = selected.iter().any(|&idx| {
+                let o = &flat_options[idx];
+                o.selection_group == *group && allowed.iter().any(|n| n == &o.name)
+            });
+            if !group_ok {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Strict "is this option consistent with the current selection?" predicate.
     ///
     /// Returns `true` only when:
-    ///   * the option is available for the current chip,
+    ///   * every `compatible` group constraint is satisfied (see
+    ///     [`Self::is_option_compatible`]),
     ///   * every one of its requirements is satisfied (including negative ones), and
     ///   * no other currently-selected option has `!{option.name}` in its `requires`.
     ///
@@ -423,7 +454,7 @@ impl ActiveConfiguration {
     /// conflicts on the understanding that selecting the row will cascade them out
     /// via [`Self::select_idx`].
     pub fn is_option_active(&self, option: &GeneratorOption) -> bool {
-        if !option.chips.is_empty() && !option.chips.contains(&self.chip) {
+        if !self.is_option_compatible(option) {
             return false;
         }
 
@@ -461,7 +492,7 @@ impl ActiveConfiguration {
     /// Callers that care about full self-consistency (CLI validation, xtask
     /// coverage) must use [`Self::is_option_active`] instead.
     pub fn is_option_toggleable(&self, option: &GeneratorOption) -> bool {
-        if !option.chips.is_empty() && !option.chips.contains(&self.chip) {
+        if !self.is_option_compatible(option) {
             return false;
         }
 
@@ -555,20 +586,35 @@ pub struct Relationships<'a> {
     pub disabled_by: Vec<&'a str>,
 }
 
+/// Find an option by name, disambiguating duplicate entries via the `compatible`
+/// constraint on the `chip` selection group.
+///
+/// The template may legitimately carry two options that share a name but target
+/// different chips (e.g. the two `probe-rs` entries with different help text).
+/// We pick the first entry whose `compatible: { chip: [...] }` allow-list
+/// includes the given chip, or — if the entry doesn't constrain `chip` at all —
+/// the first such unconstrained entry.
 pub fn find_option<'c>(
     option: &str,
     options: &'c [GeneratorOption],
     chip: Chip,
 ) -> Option<(usize, &'c GeneratorOption)> {
-    options
-        .iter()
-        .enumerate()
-        .find(|(_, opt)| opt.name == option && (opt.chips.is_empty() || opt.chips.contains(&chip)))
+    let chip_name = chip.to_string();
+    options.iter().enumerate().find(|(_, opt)| {
+        if opt.name != option {
+            return false;
+        }
+        match opt.compatible.get("chip") {
+            None => true,
+            Some(allowed) => allowed.iter().any(|n| n == &chip_name),
+        }
+    })
 }
 
 #[cfg(test)]
 mod test {
     use crate::Chip;
+    use indexmap::IndexMap;
 
     use crate::{
         config::*,
@@ -583,7 +629,7 @@ mod test {
                 display_name: "Foobar".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec!["option2".to_string()],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -591,7 +637,7 @@ mod test {
                 display_name: "Barfoo".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec![],
             }),
         ];
@@ -619,7 +665,7 @@ mod test {
                 display_name: "Foobar".to_string(),
                 selection_group: "group".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec![],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -627,7 +673,7 @@ mod test {
                 display_name: "Barfoo".to_string(),
                 selection_group: "group".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec![],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -635,7 +681,7 @@ mod test {
                 display_name: "Prevents deselecting option2".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec!["option2".to_string()],
             }),
         ];
@@ -674,7 +720,7 @@ mod test {
                         display_name: "Foobar".to_string(),
                         selection_group: "group".to_string(),
                         help: "".to_string(),
-                        chips: vec![Chip::Esp32],
+                        compatible: IndexMap::new(),
                         requires: vec![],
                     }),
                     GeneratorOptionItem::Option(GeneratorOption {
@@ -682,7 +728,7 @@ mod test {
                         display_name: "Barfoo".to_string(),
                         selection_group: "group".to_string(),
                         help: "".to_string(),
-                        chips: vec![Chip::Esp32],
+                        compatible: IndexMap::new(),
                         requires: vec![],
                     }),
                 ],
@@ -692,7 +738,7 @@ mod test {
                 display_name: "Requires any in group to be selected".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec!["group".to_string()],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -700,7 +746,7 @@ mod test {
                 display_name: "Extra option that depends on something".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec!["option3".to_string()],
             }),
         ];
@@ -739,7 +785,7 @@ mod test {
                 display_name: "Foobar".to_string(),
                 selection_group: "group".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec![],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -747,7 +793,7 @@ mod test {
                 display_name: "Barfoo".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec!["group".to_string()],
             }),
         ];
@@ -776,7 +822,7 @@ mod test {
                 display_name: "Foobar".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec![],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -784,7 +830,7 @@ mod test {
                 display_name: "Barfoo".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec!["!option1".to_string()],
             }),
         ];
@@ -825,7 +871,7 @@ mod test {
                 display_name: "probe-rs".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec![],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -833,7 +879,7 @@ mod test {
                 display_name: "log".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec!["!probe-rs".to_string()],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -841,7 +887,7 @@ mod test {
                 display_name: "embedded-test".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec!["log".to_string()],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -849,7 +895,7 @@ mod test {
                 display_name: "panic-rtt-target".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec!["probe-rs".to_string()],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -857,7 +903,7 @@ mod test {
                 display_name: "wifi".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec![],
             }),
         ];
@@ -913,20 +959,34 @@ mod test {
         // report an empty cascade — toggling it is a no-op, so advertising
         // collateral damage would be a lie.
         //
-        // Fresh config (no prior selections) with three would-be-destructive
-        // rows whose toggle is *not* actionable:
-        //   * chip-mismatch (`chips = [Esp32c6]` on an Esp32 config),
+        // Fresh config with three would-be-destructive rows whose toggle
+        // is *not* actionable:
+        //   * compatibility-mismatch (`compatible: { chip: [Esp32c6] }` with
+        //     an `esp32` selection in the `chip` group),
         //   * unmet positive requirement (`requires: ["missing"]`),
         //   * both of the above.
         // Each of them also carries `!victim`, which — without the guard —
         // `would_force_deselect` would still happily report.
+        let mut wrong_chip_compat = IndexMap::new();
+        wrong_chip_compat.insert("chip".to_string(), vec!["esp32c6".to_string()]);
         let options = vec![
+            // Stand-in for the chip selector the TUI populates at runtime.
+            // `ActiveConfiguration::select` picks this up and now drives every
+            // `compatible: { chip: [...] }` check.
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "esp32".to_string(),
+                display_name: "esp32".to_string(),
+                selection_group: "chip".to_string(),
+                help: "".to_string(),
+                compatible: IndexMap::new(),
+                requires: vec![],
+            }),
             GeneratorOptionItem::Option(GeneratorOption {
                 name: "victim".to_string(),
                 display_name: "victim".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec![],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -934,7 +994,7 @@ mod test {
                 display_name: "wrong-chip".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32c6],
+                compatible: wrong_chip_compat,
                 requires: vec!["!victim".to_string()],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -942,7 +1002,7 @@ mod test {
                 display_name: "unmet-pos".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec!["missing".to_string(), "!victim".to_string()],
             }),
             GeneratorOptionItem::Option(GeneratorOption {
@@ -950,7 +1010,7 @@ mod test {
                 display_name: "neg-conflict".to_string(),
                 selection_group: "".to_string(),
                 help: "".to_string(),
-                chips: vec![Chip::Esp32],
+                compatible: IndexMap::new(),
                 requires: vec!["!victim".to_string()],
             }),
         ];
@@ -960,6 +1020,7 @@ mod test {
             flat_options: flatten_options(&options),
             options,
         };
+        active.select("esp32");
         active.select("victim");
 
         let wrong_chip = active
@@ -992,5 +1053,79 @@ mod test {
 
     fn empty() -> &'static [usize] {
         &[]
+    }
+
+    #[test]
+    fn compatible_against_non_chip_group_hides_and_cascades() {
+        // Exercise the generalised `compatible` constraint on a group other
+        // than `chip`. A `pretty-logs` option is only compatible when the
+        // active `log-frontend` is `defmt` (not `log`); switching the group
+        // selection must cascade `pretty-logs` out of the selected set, and
+        // `is_option_compatible` must reflect the change.
+        let mut pretty_logs_compat = IndexMap::new();
+        pretty_logs_compat.insert("log-frontend".to_string(), vec!["defmt".to_string()]);
+        let options = vec![
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "defmt".to_string(),
+                display_name: "defmt".to_string(),
+                selection_group: "log-frontend".to_string(),
+                help: "".to_string(),
+                compatible: IndexMap::new(),
+                requires: vec![],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "log".to_string(),
+                display_name: "log".to_string(),
+                selection_group: "log-frontend".to_string(),
+                help: "".to_string(),
+                compatible: IndexMap::new(),
+                requires: vec![],
+            }),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "pretty-logs".to_string(),
+                display_name: "pretty-logs".to_string(),
+                selection_group: "".to_string(),
+                help: "".to_string(),
+                compatible: pretty_logs_compat,
+                requires: vec![],
+            }),
+        ];
+        let mut active = ActiveConfiguration {
+            chip: Chip::Esp32,
+            selected: vec![],
+            flat_options: flatten_options(&options),
+            options,
+        };
+
+        // Baseline: nothing picked in log-frontend, so `pretty-logs` can't be
+        // compatible and therefore can't be toggled on.
+        let pretty = active
+            .flat_options
+            .iter()
+            .find(|o| o.name == "pretty-logs")
+            .cloned()
+            .unwrap();
+        assert!(!active.is_option_compatible(&pretty));
+        assert!(!active.is_option_toggleable(&pretty));
+
+        // Picking `defmt` satisfies `compatible: { log-frontend: [defmt] }`.
+        active.select("defmt");
+        assert!(active.is_option_compatible(&pretty));
+        assert!(active.is_option_toggleable(&pretty));
+        active.select("pretty-logs");
+        assert!(active.is_selected("pretty-logs"));
+
+        // Switching to `log` (same group) swaps the selection. The cascade
+        // in `drop_unsatisfied` notices `pretty-logs` is no longer compatible
+        // and clears it — exactly the "selected options should be cleared"
+        // half of the `compatible` contract.
+        active.select("log");
+        assert!(active.is_selected("log"));
+        assert!(!active.is_selected("defmt"));
+        assert!(
+            !active.is_selected("pretty-logs"),
+            "pretty-logs must be cleared when log-frontend moves off defmt"
+        );
+        assert!(!active.is_option_compatible(&pretty));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::modules::Module;
 
 pub mod cargo;
+pub mod chip_selector;
 pub mod config;
 pub mod modules;
 pub mod template;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod template;
     clap::ValueEnum,
     strum::EnumIter,
     strum::Display,
+    strum::EnumString,
 )]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -493,10 +493,6 @@ fn main() -> Result<()> {
         // cache as "no toolchains available" — the toolchain category then
         // keeps its "Scanning installed toolchains…" placeholder.
         let mut cached_toolchains: Vec<toolchain::ToolchainInfo> = Vec::new();
-        // Tracks whether `cached_toolchains` reflects a *completed* scan. A
-        // chip switch always rebuilds; an initial population only fires once
-        // the scan finishes (or there never was one, i.e. headless-style).
-        let mut scan_finished = toolchain_scan.is_none();
         // The chip that `app.repository.options` was last built for. `None`
         // forces the first-ever rebuild regardless of whether the chip has
         // actually changed — this is how we swap the placeholder toolchain
@@ -508,24 +504,24 @@ fn main() -> Result<()> {
             // cached list is reused across chip switches, and per-chip filtering
             // happens down below in the rebuild block.
             if let Some(scan) = toolchain_scan.as_mut() {
-                match scan.try_get_toolchain_list() {
-                    None => {
-                        app.set_toolchains_loading(true);
-                    }
+                let finished = match scan.try_get_toolchain_list() {
+                    None => false,
                     Some(Ok(list)) => {
-                        if !scan_finished {
-                            cached_toolchains = list.clone();
-                            scan_finished = true;
-                        }
-                        app.set_toolchains_loading(false);
+                        cached_toolchains = list.clone();
+                        true
                     }
                     Some(Err(err)) => {
-                        if !scan_finished {
-                            log::warn!("Toolchain scan failed: {err}");
-                            scan_finished = true;
-                        }
-                        app.set_toolchains_loading(false);
+                        log::warn!("Toolchain scan failed: {err}");
+                        true
                     }
+                };
+
+                app.set_toolchains_loading(!finished);
+                if finished {
+                    // Clear state to rebuild UI with correct toolchain data.
+                    populated_for_chip = None;
+                    // Stop re-checking, scan is a one-shot process.
+                    toolchain_scan = None;
                 }
             }
 
@@ -539,6 +535,8 @@ fn main() -> Result<()> {
             // Both paths flow through the same `build_options_for_chip` +
             // `App::set_options` pair, keeping chip selection and toolchain
             // repopulation on one code path.
+
+            let scan_finished = toolchain_scan.is_none();
             let tree_chip = app.repository.config.chip;
             let desired_chip = app.repository.selected_chip().unwrap_or(tree_chip);
             let chip_changed = desired_chip != tree_chip;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ use taplo::formatter::Options;
 use crate::template_files::TEMPLATE_FILES;
 
 mod check;
-mod chip_selector;
 mod template_files;
 mod toolchain;
 mod tui;
@@ -826,7 +825,7 @@ fn build_options_for_chip(
 ) -> Vec<GeneratorOptionItem> {
     let mut options = TEMPLATE.options.clone();
     prune_chip_incompatible_options(chip, &mut options);
-    chip_selector::populate_chip_category(&mut options);
+    esp_generate::chip_selector::populate_chip_category(&mut options);
     esp_generate::modules::populate_module_category(chip, &mut options);
     if let Some(category) = toolchain_category {
         category.populate(&mut options, toolchains);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
 use esp_generate::Chip;
-use esp_generate::modules::populate_module_category;
 use esp_generate::template::{GeneratorOption, GeneratorOptionItem, Template};
 use esp_generate::{
     append_list_as_sentence,
@@ -376,15 +375,31 @@ fn main() -> Result<()> {
         Some(toolchain::start_toolchain_scan())
     };
 
-    let mut template = TEMPLATE.clone();
-    remove_incompatible_chip_options(chip, &mut template.options);
-    populate_module_category(chip, &mut template.options);
-    process_options(&template, &args)?;
-
     // Stash the toolchain-category placeholder now, before anything mutates it.
     // `populate` is idempotent against this anchor, so repeated population
     // (e.g. after a future chip switch) always starts from a known baseline.
-    let toolchain_category = toolchain::ToolchainCategory::capture(&template.options);
+    let toolchain_category = toolchain::ToolchainCategory::capture(&TEMPLATE.options);
+
+    // Build the initial options tree for the current chip. In headless mode
+    // the toolchain scan never runs, so we seed the toolchain category with
+    // `--toolchain` (if any) up front — otherwise post-build lookups for the
+    // CLI toolchain name would fail.
+    let headless_toolchain: &[String] = match (args.headless, args.toolchain.as_ref()) {
+        (true, Some(tc)) => std::slice::from_ref(tc),
+        _ => &[],
+    };
+    let initial_options =
+        build_options_for_chip(chip, toolchain_category.as_ref(), headless_toolchain);
+
+    // `process_options` validates `--option` against the options tree. We keep
+    // a transient `Template` around for just this call; the authoritative copy
+    // of the tree moves into `Repository` right after.
+    process_options(
+        &Template {
+            options: initial_options.clone(),
+        },
+        &args,
+    )?;
 
     // Initial selection for TUI/headless, including toolchain if provided.
     let mut initial_selected = args.option.clone();
@@ -392,9 +407,12 @@ fn main() -> Result<()> {
         initial_selected.push(tc.clone());
     }
 
-    let mut selected = if !args.headless {
-        let repository = tui::Repository::new(chip, template.options.clone(), &initial_selected);
+    // Single source of truth: `Repository` owns the options tree from here on.
+    // The CLI post-processing code below reads `flat_options` / `options` back
+    // out of it regardless of which branch (TUI or headless) populated them.
+    let repository = tui::Repository::new(chip, initial_options, &initial_selected);
 
+    let (mut selected, flat_options) = if !args.headless {
         let mut app = tui::App::new(repository);
 
         let mut terminal = tui::init_terminal()?;
@@ -429,16 +447,15 @@ fn main() -> Result<()> {
                                 log::warn!("{warning}");
                             }
 
-                            if let Some(category) = toolchain_category.as_ref() {
-                                category.populate(&mut template.options, &filtered.names);
-                                category.populate(
-                                    &mut app.repository.config.options,
-                                    &filtered.names,
-                                );
-                                // `selected` indexes into `flat_options`, which
-                                // `populate` did not touch. Rebuild both.
-                                app.repository.config.rebuild_indices();
-                            }
+                            // Rebuild the repository's options tree in-place.
+                            // `set_options` handles index remapping and cascades
+                            // out any selection whose requirements break.
+                            let new_options = build_options_for_chip(
+                                chip,
+                                toolchain_category.as_ref(),
+                                &filtered.names,
+                            );
+                            app.repository.set_options(chip, new_options);
 
                             toolchains_populated = true;
                         }
@@ -475,16 +492,14 @@ fn main() -> Result<()> {
         tui::restore_terminal()?;
         // done with the TUI
 
-        let Some(selected) = final_selected else {
+        let Some(sel) = final_selected else {
             return Ok(());
         };
 
-        selected
+        (sel, app.repository.config.flat_options)
     } else {
-        initial_selected
+        (initial_selected, repository.config.flat_options)
     };
-
-    let flat_options = flatten_options(&template.options);
     let mut toolchain_replaced = false;
     let selected_options = format!(
         "--chip {}{}",
@@ -505,18 +520,17 @@ fn main() -> Result<()> {
         println!("Selected options: {selected_options}");
     }
 
-    let selected_toolchain = if args.headless {
-        args.toolchain.clone()
-    } else {
-        selected.iter().find_map(|name| {
-            let (_, opt) = find_option(name, &flat_options, chip)?;
-            if opt.selection_group == "toolchain" {
-                Some(name.clone())
-            } else {
-                None
-            }
-        })
-    };
+    // Same lookup for TUI and headless: both branches populated the toolchain
+    // category in `flat_options` (TUI via scan results, headless via the
+    // `--toolchain` CLI hint), so `find_option` resolves in either case.
+    let selected_toolchain = selected.iter().find_map(|name| {
+        let (_, opt) = find_option(name, &flat_options, chip)?;
+        if opt.selection_group == "toolchain" {
+            Some(name.clone())
+        } else {
+            None
+        }
+    });
 
     let selected_module = selected.iter().find_map(|name| {
         let (_, opt) = find_option(name, &flat_options, chip)?;
@@ -693,6 +707,33 @@ fn remove_incompatible_chip_options(chip: Chip, options: &mut Vec<GeneratorOptio
             option.chips.is_empty() || option.chips.contains(&chip)
         }
     });
+}
+
+/// Build a fully-prepared options tree for the given chip off the pristine
+/// [`TEMPLATE`].
+///
+/// Applies, in order:
+///   1. chip-compat pruning (`remove_incompatible_chip_options`),
+///   2. module-category population (`modules::populate_module_category`),
+///   3. toolchain-category population (`ToolchainCategory::populate`), if a
+///      `ToolchainCategory` was captured off the original template.
+///
+/// This is the single place that knows how to turn "chip + current toolchain
+/// list" into a ready-to-use options tree, and it is deliberately cheap enough
+/// to re-run on every chip switch or scan result (no subprocesses; the
+/// toolchain info is already cached in-memory by the caller).
+fn build_options_for_chip(
+    chip: Chip,
+    toolchain_category: Option<&toolchain::ToolchainCategory>,
+    toolchains: &[String],
+) -> Vec<GeneratorOptionItem> {
+    let mut options = TEMPLATE.options.clone();
+    remove_incompatible_chip_options(chip, &mut options);
+    esp_generate::modules::populate_module_category(chip, &mut options);
+    if let Some(category) = toolchain_category {
+        category.populate(&mut options, toolchains);
+    }
+    options
 }
 
 #[derive(Clone, Copy)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1041,12 +1041,22 @@ fn process_file(
 
 fn process_options(template: &Template, args: &Args) -> Result<()> {
     let mut success = true;
-    // `template.options` is the chip-pruned tree, so its `all_options()` no
-    // longer lists options that are incompatible with the current chip. For
-    // the "Unknown option" vs "Not supported for chip …" distinction we
-    // still need the full, unpruned catalogue — fall back to the pristine
-    // `TEMPLATE` for that.
-    let all_options_full = TEMPLATE.all_options();
+    // Two option catalogues, with complementary coverage:
+    //   - `populated_options` is the chip-pruned, post-`build_options_for_chip`
+    //     view: it DOES know about dynamically-populated entries (each
+    //     supported chip in the `chip` category, each module for the current
+    //     chip in the `module` category), but it has already been filtered
+    //     down to options compatible with `--chip`.
+    //   - `pristine_options` is the raw template: it lists every
+    //     chip-restricted option (so we can tell "pruned by chip" apart from
+    //     "unknown name"), but the `chip` and `module` categories still hold
+    //     only their literal `PLACEHOLDER` !Option.
+    // Options are looked up in the populated view first — anything present
+    // there is definitionally chip-compatible — and we only consult the
+    // pristine catalogue as a fallback so that chip-pruned names surface as
+    // "Not supported for chip …" rather than "Unknown option".
+    let populated_options = template.all_options();
+    let pristine_options = TEMPLATE.all_options();
 
     let arg_chip = args.chip.unwrap();
 
@@ -1090,24 +1100,13 @@ fn process_options(template: &Template, args: &Args) -> Result<()> {
         let option = option.as_str();
         let mut option_found = false;
         let mut option_found_for_chip = false;
-        // Existence check uses the pristine template: the chip-pruned view
-        // will have dropped any option whose `compatible: { chip: [...] }`
-        // excludes `--chip`, and we don't want those to masquerade as
-        // "Unknown option".
-        for &option_item in all_options_full.iter().filter(|item| item.name == option) {
+
+        // Primary lookup: the populated, chip-pruned view. Any match here is
+        // automatically both "known" and "compatible with --chip", and — for
+        // dynamically-populated names (chip/module entries) — this is the
+        // only view that actually lists them by name.
+        for &option_item in populated_options.iter().filter(|item| item.name == option) {
             option_found = true;
-
-            // Check if the chip is supported. An option that doesn't constrain the
-            // `chip` group in its `compatible` map is considered chip-agnostic.
-            // We don't immediately fail in case the option is not present for the chip, because
-            // it may exist as a separate entry (e.g. with different properties).
-            if let Some(allowed) = option_item.compatible.get("chip") {
-                let chip_name = arg_chip.to_string();
-                if !allowed.iter().any(|n| n == &chip_name) {
-                    continue;
-                }
-            }
-
             option_found_for_chip = true;
 
             // Is the option allowed to be selected?
@@ -1151,6 +1150,26 @@ fn process_options(template: &Template, args: &Args) -> Result<()> {
 
             for disabled in disabled_by {
                 log::error!("Option '{}' is disabled by {}", option_item.name, disabled);
+            }
+        }
+
+        // Fallback lookup: consult the pristine template only if the
+        // populated view didn't know the name, so that static options pruned
+        // out by chip compatibility are reported as "Not supported for chip
+        // …" rather than "Unknown option". Dynamic (chip/module) names never
+        // appear here — but they'll always be found in the populated view
+        // above, so we don't need to special-case them.
+        if !option_found {
+            for &option_item in pristine_options.iter().filter(|item| item.name == option) {
+                option_found = true;
+
+                if let Some(allowed) = option_item.compatible.get("chip") {
+                    let chip_name = arg_chip.to_string();
+                    if !allowed.iter().any(|n| n == &chip_name) {
+                        continue;
+                    }
+                }
+                option_found_for_chip = true;
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,10 +49,6 @@ struct Args {
     /// Name of the project to generate
     name: Option<String>,
 
-    /// Chip to target
-    #[arg(short, long)]
-    chip: Option<Chip>,
-
     /// Run in headless mode (i.e. do not use the TUI)
     #[arg(long)]
     headless: bool,
@@ -158,6 +154,22 @@ impl SubCommands {
             }
         }
 
+        // Populate the `chip` category so chips show up under their real
+        // names (`esp32c6` etc.) rather than the static `PLACEHOLDER` entry
+        // that ships in the YAML. The chip is a valid `-o` target now, so
+        // `list-options`/`explain` must be able to describe it.
+        //
+        // `module` and `toolchain` are intentionally *not* populated here:
+        // modules are chip-specific (so a chip-agnostic listing has nothing
+        // useful to say) and toolchains are discovered from the user's
+        // rustup install at runtime. Those two groups are filtered out of
+        // the listing below instead.
+        let mut populated_options = TEMPLATE.options.clone();
+        esp_generate::chip_selector::populate_chip_category(&mut populated_options);
+        let populated = Template {
+            options: populated_options,
+        };
+
         match self {
             SubCommands::ListOptions => {
                 println!(
@@ -165,10 +177,12 @@ impl SubCommands {
                 );
                 let mut groups = IndexMap::new();
                 let mut seen = HashSet::new();
-                let all_options = TEMPLATE.all_options();
-                for (index, option) in all_options.iter().enumerate().filter(|(_, o)| {
-                    !["toolchain", "module", "chip"].contains(&o.selection_group.as_str())
-                }) {
+                let all_options = populated.all_options();
+                for (index, option) in all_options
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, o)| !["toolchain", "module"].contains(&o.selection_group.as_str()))
+                {
                     let group = groups.entry(&option.selection_group).or_insert(Vec::new());
 
                     if seen.insert(&option.name) {
@@ -204,7 +218,7 @@ impl SubCommands {
                 Ok(())
             }
             SubCommands::Explain { option } => {
-                let all_options = TEMPLATE.all_options();
+                let all_options = populated.all_options();
                 if let Some(option) = all_options.iter().find(|o| &o.name == option) {
                     println!(
                         "Option: {}\n\n{}{}",
@@ -290,14 +304,26 @@ fn about() -> String {
     about
 }
 
+/// Scan the user's `-o`/`--option` list for an entry that names a [`Chip`]
+/// variant. The chip is no longer a first-class CLI flag; it travels with the
+/// rest of the generation options, so `-o esp32c6` both picks the target and
+/// ticks the matching entry in the `chip` selection group.
+///
+/// Returns the first match. If the user passes multiple chip options (which
+/// is meaningless since they share a selection group), the conflict is
+/// surfaced later by [`process_options`] via the `same_selection_group` check.
+fn chip_from_options(options: &[String]) -> Option<Chip> {
+    options.iter().find_map(|opt| opt.parse::<Chip>().ok())
+}
+
 fn setup_args_interactive(args: &mut Args) -> Result<()> {
     if args.headless {
         let mut missing = String::from(
             "You are in headless mode, but esp-generate needs more information to generate your project.",
         );
-        if args.chip.is_none() {
+        if chip_from_options(&args.option).is_none() {
             missing.push_str(
-                "\nThe target chip is missing. Add --chip <your-chip-name> to the command.",
+                "\nThe target chip is missing. Add `-o <your-chip-name>` (e.g. `-o esp32c6`) to the command.",
             );
         }
         if args.name.is_none() {
@@ -307,11 +333,11 @@ fn setup_args_interactive(args: &mut Args) -> Result<()> {
         bail!("{missing}");
     }
 
-    // The chip is no longer prompted for up front: the TUI exposes it as a
+    // The chip is not prompted for up front: the TUI exposes it as a
     // first-class selection group ("chip" category), so users can pick — and
-    // switch — the target chip interactively. When `--chip` is omitted we just
-    // seed the TUI with a reasonable default; the user can change it from the
-    // first menu level.
+    // switch — the target chip interactively. When no chip is passed on the
+    // command line we just seed the TUI with a reasonable default; the user
+    // can change it from the first menu level.
 
     if args.name.is_none() {
         let project_name = Text::new("Enter project name:")
@@ -341,25 +367,24 @@ fn main() -> Result<()> {
         check_for_update(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
     }
 
-    // Run the interactive TUI only if chip or name is missing
-    if args.chip.is_none() || args.name.is_none() {
+    // Run the interactive TUI only if chip or name is missing. Both checks
+    // happen against the `-o` list (chip is just another option now) plus
+    // `args.name` — headless mode is rejected inside `setup_args_interactive`
+    // if either piece is still missing.
+    if chip_from_options(&args.option).is_none() || args.name.is_none() {
         setup_args_interactive(&mut args)?;
     }
 
-    // In TUI mode the chip is a normal selection group now — if the user
-    // didn't pass `--chip`, just seed the session with the first chip variant
-    // and let them switch from the TUI. Headless mode still requires an
-    // explicit `--chip`, which `setup_args_interactive` enforces.
-    if args.chip.is_none() {
-        args.chip = Some(
-            Chip::iter()
-                .next()
-                .expect("at least one chip variant must exist"),
-        );
-    }
-    // Initial chip — may be replaced after the TUI closes if the user picked
-    // a different one from the in-TUI chip selector.
-    let mut chip = args.chip.unwrap();
+    // In TUI mode the chip is a normal selection group — if the user didn't
+    // pass one via `-o`, just seed the session with the first chip variant
+    // and let them switch from the TUI. Headless mode has already been
+    // rejected above if the user didn't provide a chip, so the `unwrap_or`
+    // branch only runs in the TUI path.
+    let mut chip = chip_from_options(&args.option).unwrap_or_else(|| {
+        Chip::iter()
+            .next()
+            .expect("at least one chip variant must exist")
+    });
 
     let name = args.name.clone().unwrap();
 
@@ -432,15 +457,19 @@ fn main() -> Result<()> {
             options: initial_options.clone(),
         },
         &args,
+        chip,
     )?;
 
     // Initial selection for TUI/headless, including toolchain if provided.
-    // The chip name goes in too so that the `chip` selection group starts with
-    // the user-requested (or defaulted) chip ticked — otherwise the chip
-    // category would render with nothing selected, and the TUI chip-switch
-    // detector would immediately force a spurious rebuild.
+    // Users passing a chip via `-o` already have it in `args.option`; only
+    // append the (defaulted) chip when it isn't already present, so the
+    // `chip` selection group starts with the right entry ticked without
+    // creating a duplicate selected index.
     let mut initial_selected = args.option.clone();
-    initial_selected.push(chip.to_string());
+    let chip_name = chip.to_string();
+    if !initial_selected.iter().any(|o| o == &chip_name) {
+        initial_selected.push(chip_name);
+    }
     if let Some(ref tc) = args.toolchain {
         initial_selected.push(tc.clone());
     }
@@ -513,8 +542,7 @@ fn main() -> Result<()> {
             let tree_chip = app.repository.config.chip;
             let desired_chip = app.repository.selected_chip().unwrap_or(tree_chip);
             let chip_changed = desired_chip != tree_chip;
-            let needs_initial_populate =
-                scan_finished && populated_for_chip != Some(desired_chip);
+            let needs_initial_populate = scan_finished && populated_for_chip != Some(desired_chip);
 
             if chip_changed || needs_initial_populate {
                 let filtered = toolchain::toolchains_for_chip(
@@ -573,18 +601,10 @@ fn main() -> Result<()> {
         (initial_selected, repository.config.flat_options)
     };
     let mut toolchain_replaced = false;
-    // The chip group option name (e.g. "esp32c6") is in `selected` thanks to
-    // the in-TUI chip selector, but it's already represented by `--chip` in
-    // the command-line prefix. Skip it here so the regenerated command has
-    // no redundant `-o esp32c6`.
-    let chip_name = chip.to_string();
-    let selected_options = format!(
-        "--chip {}{}",
-        chip,
-        selected.iter().fold(String::new(), |mut acc, s| {
-            if s == &chip_name {
-                return acc;
-            }
+
+    let selected_options = selected
+        .iter()
+        .fold(String::new(), |mut acc, s| {
             if Some(s) == args.toolchain.as_ref() && !toolchain_replaced {
                 acc.push_str(" --toolchain ");
                 // Just in case someone decides to call their toolchain `defmt`, make sure we only replace it once
@@ -595,7 +615,8 @@ fn main() -> Result<()> {
             acc.push_str(s);
             acc
         })
-    );
+        .trim_start()
+        .to_string();
     if !args.headless {
         println!("Selected options: {selected_options}");
     }
@@ -1038,18 +1059,18 @@ fn process_file(
     Some(res)
 }
 
-fn process_options(template: &Template, args: &Args) -> Result<()> {
+fn process_options(template: &Template, args: &Args, chip: Chip) -> Result<()> {
     let mut success = true;
     // Two option catalogues, with complementary coverage:
     //   - `populated_options` is the chip-pruned, post-`build_options_for_chip`
     //     view: it DOES know about dynamically-populated entries (each
     //     supported chip in the `chip` category, each module for the current
     //     chip in the `module` category), but it has already been filtered
-    //     down to options compatible with `--chip`.
+    //     down to options compatible with the selected chip.
     //   - `pristine_options` is the raw template: it lists every
     //     chip-restricted option (so we can tell "pruned by chip" apart from
-    //     "unknown name"), but the `chip` and `module` categories still hold
-    //     only their literal `PLACEHOLDER` !Option.
+    //     "unknown name"), but the `module` category still holds only its
+    //     literal `PLACEHOLDER` !Option.
     // Options are looked up in the populated view first — anything present
     // there is definitionally chip-compatible — and we only consult the
     // pristine catalogue as a fallback so that chip-pruned names surface as
@@ -1057,15 +1078,13 @@ fn process_options(template: &Template, args: &Args) -> Result<()> {
     let populated_options = template.all_options();
     let pristine_options = TEMPLATE.all_options();
 
-    let arg_chip = args.chip.unwrap();
-
-    // Seed the simulated selection with the CLI `--option` list plus the
-    // synthetic chip-group entry named after `--chip`. The chip entry is
-    // essential now that chip restrictions live in `compatible: { chip: [...] }`
-    // rather than in a dedicated `chips:` field: without it, every
-    // chip-restricted option would fail `is_option_compatible` and look
-    // "invalid" to the validator.
-    let chip_name = arg_chip.to_string();
+    // Seed the simulated selection with the CLI `-o` list. The chip entry —
+    // now just another `-o` option — is already in `args.option` if the user
+    // asked for it; if they didn't (TUI default path), add it synthetically
+    // so that option-level `compatible: { chip: [...] }` constraints are
+    // satisfied during validation. Without it, every chip-restricted option
+    // would fail `is_option_compatible` and look "invalid" to the validator.
+    let chip_name = chip.to_string();
     let flat_options = flatten_options(&template.options);
     let mut selected: Vec<usize> = args
         .option
@@ -1081,7 +1100,7 @@ fn process_options(template: &Template, args: &Args) -> Result<()> {
     }
 
     let selected_config = ActiveConfiguration {
-        chip: arg_chip,
+        chip,
         selected,
         flat_options,
         options: template.options.clone(),
@@ -1089,10 +1108,10 @@ fn process_options(template: &Template, args: &Args) -> Result<()> {
 
     let mut same_selection_group: HashMap<&str, Vec<&str>> = HashMap::new();
 
-    // Iterate the user's CLI `--option` list directly rather than the
-    // resolved indices in `selected_config.selected`: an option that got
-    // pruned out of the chip-specific tree (because it isn't compatible
-    // with `--chip`) never makes it into `flat_options` and would be
+    // Iterate the user's CLI `-o` list directly rather than the resolved
+    // indices in `selected_config.selected`: an option that got pruned out
+    // of the chip-specific tree (because it isn't compatible with the
+    // selected chip) never makes it into `flat_options` and would be
     // silently dropped here otherwise. We still want to surface a proper
     // "Not supported for chip …" diagnostic in that case.
     for option in &args.option {
@@ -1101,9 +1120,9 @@ fn process_options(template: &Template, args: &Args) -> Result<()> {
         let mut option_found_for_chip = false;
 
         // Primary lookup: the populated, chip-pruned view. Any match here is
-        // automatically both "known" and "compatible with --chip", and — for
-        // dynamically-populated names (chip/module entries) — this is the
-        // only view that actually lists them by name.
+        // automatically both "known" and "compatible with the selected chip",
+        // and — for dynamically-populated names (module entries) — this is
+        // the only view that actually lists them by name.
         for &option_item in populated_options.iter().filter(|item| item.name == option) {
             option_found = true;
             option_found_for_chip = true;
@@ -1155,7 +1174,7 @@ fn process_options(template: &Template, args: &Args) -> Result<()> {
         // Fallback lookup: consult the pristine template only if the
         // populated view didn't know the name, so that static options pruned
         // out by chip compatibility are reported as "Not supported for chip
-        // …" rather than "Unknown option". Dynamic (chip/module) names never
+        // …" rather than "Unknown option". Dynamic (module) names never
         // appear here — but they'll always be found in the populated view
         // above, so we don't need to special-case them.
         if !option_found {
@@ -1163,7 +1182,6 @@ fn process_options(template: &Template, args: &Args) -> Result<()> {
                 option_found = true;
 
                 if let Some(allowed) = option_item.compatible.get("chip") {
-                    let chip_name = arg_chip.to_string();
                     if !allowed.iter().any(|n| n == &chip_name) {
                         continue;
                     }
@@ -1176,7 +1194,7 @@ fn process_options(template: &Template, args: &Args) -> Result<()> {
             log::error!("Unknown option '{option}'");
             success = false;
         } else if !option_found_for_chip {
-            log::error!("Option '{option}' is not supported for chip {arg_chip}");
+            log::error!("Option '{option}' is not supported for chip {chip}");
             success = false;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use esp_generate::{
     config::{find_option, flatten_options},
 };
 use indexmap::IndexMap;
-use inquire::{Select, Text};
+use inquire::Text;
 use ratatui::crossterm::event;
 use std::collections::HashSet;
 use std::fmt::Write;
@@ -29,6 +29,7 @@ use taplo::formatter::Options;
 use crate::template_files::TEMPLATE_FILES;
 
 mod check;
+mod chip_selector;
 mod template_files;
 mod toolchain;
 mod tui;
@@ -142,11 +143,9 @@ impl SubCommands {
                 let mut groups = IndexMap::new();
                 let mut seen = HashSet::new();
                 let all_options = TEMPLATE.all_options();
-                for (index, option) in all_options
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, o)| !["toolchain", "module"].contains(&o.selection_group.as_str()))
-                {
+                for (index, option) in all_options.iter().enumerate().filter(|(_, o)| {
+                    !["toolchain", "module", "chip"].contains(&o.selection_group.as_str())
+                }) {
                     let group = groups.entry(&option.selection_group).or_insert(Vec::new());
 
                     if seen.insert(&option.name) {
@@ -285,13 +284,11 @@ fn setup_args_interactive(args: &mut Args) -> Result<()> {
         bail!("{missing}");
     }
 
-    if args.chip.is_none() {
-        let chip_variants = Chip::iter().collect::<Vec<_>>();
-
-        let chip = Select::new("Select your target chip:", chip_variants).prompt()?;
-
-        args.chip = Some(chip);
-    }
+    // The chip is no longer prompted for up front: the TUI exposes it as a
+    // first-class selection group ("chip" category), so users can pick — and
+    // switch — the target chip interactively. When `--chip` is omitted we just
+    // seed the TUI with a reasonable default; the user can change it from the
+    // first menu level.
 
     if args.name.is_none() {
         let project_name = Text::new("Enter project name:")
@@ -326,7 +323,20 @@ fn main() -> Result<()> {
         setup_args_interactive(&mut args)?;
     }
 
-    let chip = args.chip.unwrap();
+    // In TUI mode the chip is a normal selection group now — if the user
+    // didn't pass `--chip`, just seed the session with the first chip variant
+    // and let them switch from the TUI. Headless mode still requires an
+    // explicit `--chip`, which `setup_args_interactive` enforces.
+    if args.chip.is_none() {
+        args.chip = Some(
+            Chip::iter()
+                .next()
+                .expect("at least one chip variant must exist"),
+        );
+    }
+    // Initial chip — may be replaced after the TUI closes if the user picked
+    // a different one from the in-TUI chip selector.
+    let mut chip = args.chip.unwrap();
 
     let name = args.name.clone().unwrap();
 
@@ -402,7 +412,12 @@ fn main() -> Result<()> {
     )?;
 
     // Initial selection for TUI/headless, including toolchain if provided.
+    // The chip name goes in too so that the `chip` selection group starts with
+    // the user-requested (or defaulted) chip ticked — otherwise the chip
+    // category would render with nothing selected, and the TUI chip-switch
+    // detector would immediately force a spurious rebuild.
     let mut initial_selected = args.option.clone();
+    initial_selected.push(chip.to_string());
     if let Some(ref tc) = args.toolchain {
         initial_selected.push(tc.clone());
     }
@@ -419,55 +434,83 @@ fn main() -> Result<()> {
 
         let mut final_selected: Option<Vec<String>> = None;
         let mut running = true;
-        let mut toolchains_populated = false;
+
+        // Latest successful toolchain scan, cached so that per-chip filtering
+        // (and any subsequent chip switches) can rerun without re-scanning.
+        // Starts empty; the options-tree rebuild loop below treats an empty
+        // cache as "no toolchains available" — the toolchain category then
+        // keeps its "Scanning installed toolchains…" placeholder.
+        let mut cached_toolchains: Vec<toolchain::ToolchainInfo> = Vec::new();
+        // Tracks whether `cached_toolchains` reflects a *completed* scan. A
+        // chip switch always rebuilds; an initial population only fires once
+        // the scan finishes (or there never was one, i.e. headless-style).
+        let mut scan_finished = toolchain_scan.is_none();
+        // The chip that `app.repository.options` was last built for. `None`
+        // forces the first-ever rebuild regardless of whether the chip has
+        // actually changed — this is how we swap the placeholder toolchain
+        // category out for real entries once the scan completes.
+        let mut populated_for_chip: Option<Chip> = None;
 
         while running {
-            // Toolchain scan in the background.
-            // In order to prevent the application from being slow,
-            // toolchain scanning and filtering is done in a separate thread
-            // and we poll the result before each frame is drawn
+            // Toolchain scan in the background. Chip-agnostic on purpose: the
+            // cached list is reused across chip switches, and per-chip filtering
+            // happens down below in the rebuild block.
             if let Some(scan) = toolchain_scan.as_mut() {
                 match scan.try_get_toolchain_list() {
                     None => {
-                        // still loading
                         app.set_toolchains_loading(true);
                     }
                     Some(Ok(list)) => {
-                        if !toolchains_populated {
-                            // Derive a per-chip view from the cached chip-agnostic
-                            // scan. This is pure and cheap, so it can be re-run
-                            // from anywhere once dynamic chip selection lands.
-                            let filtered = toolchain::toolchains_for_chip(
-                                list,
-                                chip,
-                                &msrv,
-                                args.toolchain.as_deref(),
-                            );
-                            for warning in &filtered.warnings {
-                                log::warn!("{warning}");
-                            }
-
-                            // Rebuild the repository's options tree in-place.
-                            // `set_options` handles index remapping and cascades
-                            // out any selection whose requirements break.
-                            let new_options = build_options_for_chip(
-                                chip,
-                                toolchain_category.as_ref(),
-                                &filtered.names,
-                            );
-                            app.repository.set_options(chip, new_options);
-
-                            toolchains_populated = true;
+                        if !scan_finished {
+                            cached_toolchains = list.clone();
+                            scan_finished = true;
                         }
                         app.set_toolchains_loading(false);
                     }
-
                     Some(Err(err)) => {
-                        log::warn!("Toolchain scan failed: {err}");
+                        if !scan_finished {
+                            log::warn!("Toolchain scan failed: {err}");
+                            scan_finished = true;
+                        }
                         app.set_toolchains_loading(false);
-                        toolchains_populated = true;
                     }
                 }
+            }
+
+            // Rebuild-on-demand:
+            //   * `selected_chip` diverges from the tree's chip → user picked
+            //     a different chip in the `chip` category; rebuild the whole
+            //     tree for that chip and collapse the menu to the root so the
+            //     user isn't stranded inside a now-irrelevant category.
+            //   * scan just finished or we haven't populated yet → rebuild to
+            //     swap the toolchain placeholder for real entries.
+            // Both paths flow through the same `build_options_for_chip` +
+            // `App::set_options` pair, keeping chip selection and toolchain
+            // repopulation on one code path.
+            let tree_chip = app.repository.config.chip;
+            let desired_chip = app.repository.selected_chip().unwrap_or(tree_chip);
+            let chip_changed = desired_chip != tree_chip;
+            let needs_initial_populate =
+                scan_finished && populated_for_chip != Some(desired_chip);
+
+            if chip_changed || needs_initial_populate {
+                let filtered = toolchain::toolchains_for_chip(
+                    &cached_toolchains,
+                    desired_chip,
+                    &msrv,
+                    args.toolchain.as_deref(),
+                );
+                for warning in &filtered.warnings {
+                    log::warn!("{warning}");
+                }
+
+                let new_options = build_options_for_chip(
+                    desired_chip,
+                    toolchain_category.as_ref(),
+                    &filtered.names,
+                );
+                app.set_options(desired_chip, new_options, chip_changed);
+                populated_for_chip = Some(desired_chip);
             }
 
             // draw a frame
@@ -496,15 +539,29 @@ fn main() -> Result<()> {
             return Ok(());
         };
 
+        // Pick up whatever chip the TUI ended on. The user may have switched
+        // chips mid-session; everything downstream (linker config, template
+        // variables, validation) must match the chip the options were built
+        // against.
+        chip = app.repository.config.chip;
+
         (sel, app.repository.config.flat_options)
     } else {
         (initial_selected, repository.config.flat_options)
     };
     let mut toolchain_replaced = false;
+    // The chip group option name (e.g. "esp32c6") is in `selected` thanks to
+    // the in-TUI chip selector, but it's already represented by `--chip` in
+    // the command-line prefix. Skip it here so the regenerated command has
+    // no redundant `-o esp32c6`.
+    let chip_name = chip.to_string();
     let selected_options = format!(
         "--chip {}{}",
         chip,
         selected.iter().fold(String::new(), |mut acc, s| {
+            if s == &chip_name {
+                return acc;
+            }
             if Some(s) == args.toolchain.as_ref() && !toolchain_replaced {
                 acc.push_str(" --toolchain ");
                 // Just in case someone decides to call their toolchain `defmt`, make sure we only replace it once
@@ -729,6 +786,7 @@ fn build_options_for_chip(
 ) -> Vec<GeneratorOptionItem> {
     let mut options = TEMPLATE.options.clone();
     remove_incompatible_chip_options(chip, &mut options);
+    chip_selector::populate_chip_category(&mut options);
     esp_generate::modules::populate_module_category(chip, &mut options);
     if let Some(category) = toolchain_category {
         category.populate(&mut options, toolchains);

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,14 +105,38 @@ enum SubCommands {
 impl SubCommands {
     fn handle(&self) -> Result<()> {
         fn chip_info_text(options: &[&GeneratorOption], opt: &GeneratorOption) -> String {
-            let mut chips = Vec::new();
+            // Merge the `compatible: { chip: [...] }` allow-lists from every
+            // variant sharing this name (there can be more than one — see the
+            // two `probe-rs` entries in the template). An option that omits
+            // the `chip` entry entirely is considered chip-agnostic, which we
+            // represent by "all chips allowed" so that the final union is a
+            // no-op.
+            let mut chips: Vec<Chip> = Vec::new();
+            let mut all_chip_agnostic = true;
             for option in options.iter().filter(|o| o.name == opt.name) {
-                chips.extend_from_slice(&option.chips);
+                match option.compatible.get("chip") {
+                    None => {
+                        all_chip_agnostic = true;
+                        chips.clear();
+                        chips.extend(Chip::iter());
+                        break;
+                    }
+                    Some(names) => {
+                        all_chip_agnostic = false;
+                        for name in names {
+                            if let Ok(chip) = name.parse::<Chip>()
+                                && !chips.contains(&chip)
+                            {
+                                chips.push(chip);
+                            }
+                        }
+                    }
+                }
             }
 
             let chip_count = Chip::iter().count();
 
-            if chips.is_empty() || chips.len() == chip_count {
+            if all_chip_agnostic || chips.len() == chip_count {
                 String::new()
             } else if chips.len() < chip_count / 2 {
                 format!(
@@ -754,15 +778,31 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn remove_incompatible_chip_options(chip: Chip, options: &mut Vec<GeneratorOptionItem>) {
+/// Prune every option whose `compatible: { chip: [...] }` allow-list excludes
+/// the given chip. Options that don't constrain `chip` (or that don't have a
+/// `compatible` entry at all) are kept. Empty categories are dropped.
+///
+/// This is the generalised replacement for the old `remove_incompatible_chip_options`
+/// pass: compatibility is evaluated from the `compatible` map on
+/// [`GeneratorOption`] against the chip the TUI currently has selected in the
+/// `chip` selection group, instead of the retired `chips: Vec<Chip>` field.
+///
+/// Only the `chip` group is evaluated here because it's the only group whose
+/// selection is already known at tree-build time. Any other `compatible`
+/// constraints are evaluated at runtime by
+/// [`crate::config::ActiveConfiguration::is_option_compatible`] and are
+/// enforced via the cascade in [`drop_unsatisfied`].
+fn prune_chip_incompatible_options(chip: Chip, options: &mut Vec<GeneratorOptionItem>) {
+    let chip_name = chip.to_string();
     options.retain_mut(|opt| match opt {
         GeneratorOptionItem::Category(category) => {
-            remove_incompatible_chip_options(chip, &mut category.options);
+            prune_chip_incompatible_options(chip, &mut category.options);
             !category.options.is_empty()
         }
-        GeneratorOptionItem::Option(option) => {
-            option.chips.is_empty() || option.chips.contains(&chip)
-        }
+        GeneratorOptionItem::Option(option) => match option.compatible.get("chip") {
+            None => true,
+            Some(allowed) => allowed.iter().any(|n| n == &chip_name),
+        },
     });
 }
 
@@ -770,7 +810,7 @@ fn remove_incompatible_chip_options(chip: Chip, options: &mut Vec<GeneratorOptio
 /// [`TEMPLATE`].
 ///
 /// Applies, in order:
-///   1. chip-compat pruning (`remove_incompatible_chip_options`),
+///   1. chip-compat pruning (`prune_chip_incompatible_options`),
 ///   2. module-category population (`modules::populate_module_category`),
 ///   3. toolchain-category population (`ToolchainCategory::populate`), if a
 ///      `ToolchainCategory` was captured off the original template.
@@ -785,7 +825,7 @@ fn build_options_for_chip(
     toolchains: &[String],
 ) -> Vec<GeneratorOptionItem> {
     let mut options = TEMPLATE.options.clone();
-    remove_incompatible_chip_options(chip, &mut options);
+    prune_chip_incompatible_options(chip, &mut options);
     chip_selector::populate_chip_category(&mut options);
     esp_generate::modules::populate_module_category(chip, &mut options);
     if let Some(category) = toolchain_category {
@@ -1001,37 +1041,71 @@ fn process_file(
 
 fn process_options(template: &Template, args: &Args) -> Result<()> {
     let mut success = true;
-    let all_options = template.all_options();
+    // `template.options` is the chip-pruned tree, so its `all_options()` no
+    // longer lists options that are incompatible with the current chip. For
+    // the "Unknown option" vs "Not supported for chip …" distinction we
+    // still need the full, unpruned catalogue — fall back to the pristine
+    // `TEMPLATE` for that.
+    let all_options_full = TEMPLATE.all_options();
 
     let arg_chip = args.chip.unwrap();
 
+    // Seed the simulated selection with the CLI `--option` list plus the
+    // synthetic chip-group entry named after `--chip`. The chip entry is
+    // essential now that chip restrictions live in `compatible: { chip: [...] }`
+    // rather than in a dedicated `chips:` field: without it, every
+    // chip-restricted option would fail `is_option_compatible` and look
+    // "invalid" to the validator.
+    let chip_name = arg_chip.to_string();
     let flat_options = flatten_options(&template.options);
+    let mut selected: Vec<usize> = args
+        .option
+        .iter()
+        .flat_map(|opt_name| flat_options.iter().position(|o| &o.name == opt_name))
+        .collect();
+    if let Some(pos) = flat_options
+        .iter()
+        .position(|o| o.selection_group == "chip" && o.name == chip_name)
+        && !selected.contains(&pos)
+    {
+        selected.push(pos);
+    }
+
     let selected_config = ActiveConfiguration {
         chip: arg_chip,
-        selected: args
-            .option
-            .iter()
-            .flat_map(|opt_name| flat_options.iter().position(|o| &o.name == opt_name))
-            .collect(),
+        selected,
         flat_options,
         options: template.options.clone(),
     };
 
     let mut same_selection_group: HashMap<&str, Vec<&str>> = HashMap::new();
 
-    for option in &selected_config.selected {
-        let option = selected_config.flat_options[*option].name.as_str();
-        // Find the matching option in the template
+    // Iterate the user's CLI `--option` list directly rather than the
+    // resolved indices in `selected_config.selected`: an option that got
+    // pruned out of the chip-specific tree (because it isn't compatible
+    // with `--chip`) never makes it into `flat_options` and would be
+    // silently dropped here otherwise. We still want to surface a proper
+    // "Not supported for chip …" diagnostic in that case.
+    for option in &args.option {
+        let option = option.as_str();
         let mut option_found = false;
         let mut option_found_for_chip = false;
-        for &option_item in all_options.iter().filter(|item| item.name == option) {
-            option_found = true; // The input refers to an existing option.
+        // Existence check uses the pristine template: the chip-pruned view
+        // will have dropped any option whose `compatible: { chip: [...] }`
+        // excludes `--chip`, and we don't want those to masquerade as
+        // "Unknown option".
+        for &option_item in all_options_full.iter().filter(|item| item.name == option) {
+            option_found = true;
 
-            // Check if the chip is supported. If the chip list is empty, all chips are supported.
+            // Check if the chip is supported. An option that doesn't constrain the
+            // `chip` group in its `compatible` map is considered chip-agnostic.
             // We don't immediately fail in case the option is not present for the chip, because
             // it may exist as a separate entry (e.g. with different properties).
-            if !option_item.chips.contains(&arg_chip) && !option_item.chips.is_empty() {
-                continue;
+            if let Some(allowed) = option_item.compatible.get("chip") {
+                let chip_name = arg_chip.to_string();
+                if !allowed.iter().any(|n| n == &chip_name) {
+                    continue;
+                }
             }
 
             option_found_for_chip = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,21 +366,25 @@ fn main() -> Result<()> {
 
     let msrv: check::Version = versions.msrv().parse().unwrap();
 
-    // Start toolchain scan as early as we know chip and msrv (TUI only).
+    // Start toolchain scan as early as possible (TUI only). The scan itself is
+    // chip-agnostic — chip/MSRV/CLI hint are applied later by
+    // `toolchain::toolchains_for_chip` against the cached result, which makes
+    // dynamic chip selection possible without re-scanning.
     let mut toolchain_scan = if args.headless {
         None
     } else {
-        Some(toolchain::start_toolchain_scan(
-            chip,
-            args.toolchain.clone(),
-            msrv.clone(),
-        ))
+        Some(toolchain::start_toolchain_scan())
     };
 
     let mut template = TEMPLATE.clone();
     remove_incompatible_chip_options(chip, &mut template.options);
     populate_module_category(chip, &mut template.options);
     process_options(&template, &args)?;
+
+    // Stash the toolchain-category placeholder now, before anything mutates it.
+    // `populate` is idempotent against this anchor, so repeated population
+    // (e.g. after a future chip switch) always starts from a known baseline.
+    let toolchain_category = toolchain::ToolchainCategory::capture(&template.options);
 
     // Initial selection for TUI/headless, including toolchain if provided.
     let mut initial_selected = args.option.clone();
@@ -412,17 +416,29 @@ fn main() -> Result<()> {
                     }
                     Some(Ok(list)) => {
                         if !toolchains_populated {
-                            toolchain::populate_toolchain_category_from_list(
-                                &mut template.options,
-                                &mut Vec::new(),
+                            // Derive a per-chip view from the cached chip-agnostic
+                            // scan. This is pure and cheap, so it can be re-run
+                            // from anywhere once dynamic chip selection lands.
+                            let filtered = toolchain::toolchains_for_chip(
                                 list,
-                            )?;
+                                chip,
+                                &msrv,
+                                args.toolchain.as_deref(),
+                            );
+                            for warning in &filtered.warnings {
+                                log::warn!("{warning}");
+                            }
 
-                            toolchain::populate_toolchain_category_from_list(
-                                &mut app.repository.config.options,
-                                &mut app.repository.config.flat_options,
-                                list,
-                            )?;
+                            if let Some(category) = toolchain_category.as_ref() {
+                                category.populate(&mut template.options, &filtered.names);
+                                category.populate(
+                                    &mut app.repository.config.options,
+                                    &filtered.names,
+                                );
+                                // `selected` indexes into `flat_options`, which
+                                // `populate` did not touch. Rebuild both.
+                                app.repository.config.rebuild_indices();
+                            }
 
                             toolchains_populated = true;
                         }

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,16 @@
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-use crate::Chip;
+/// Map from selection-group name to the subset of options in that group that
+/// are compatible with this item. If any listed group has no current selection
+/// — or its selection is outside the allow-list — the item is considered
+/// incompatible and is hidden from the TUI (and its selection, if any, is
+/// cleared). Absent groups are unconstrained.
+///
+/// This generalises what `chips: [...]` used to express: a chip restriction
+/// is now just a `compatible: { chip: [...] }` entry driven by the `chip`
+/// selection group the TUI populates at runtime.
+pub type CompatibilityRequirements = IndexMap<String, Vec<String>>;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct GeneratorOption {
@@ -13,8 +23,10 @@ pub struct GeneratorOption {
     pub help: String,
     #[serde(default)]
     pub requires: Vec<String>,
+    /// Per-selection-group compatibility allow-lists. See
+    /// [`CompatibilityRequirements`].
     #[serde(default)]
-    pub chips: Vec<Chip>,
+    pub compatible: CompatibilityRequirements,
 }
 
 impl GeneratorOption {
@@ -77,10 +89,13 @@ impl GeneratorOptionItem {
         matches!(self, GeneratorOptionItem::Category(_))
     }
 
-    pub fn chips(&self) -> &[Chip] {
+    /// Per-group compatibility allow-list for this item. Categories don't
+    /// currently carry their own compatibility constraints — they derive
+    /// from their children via [`ActiveConfiguration::is_active`].
+    pub fn compatible(&self) -> Option<&CompatibilityRequirements> {
         match self {
-            GeneratorOptionItem::Category(_) => &[],
-            GeneratorOptionItem::Option(option) => option.chips.as_slice(),
+            GeneratorOptionItem::Category(_) => None,
+            GeneratorOptionItem::Option(option) => Some(&option.compatible),
         }
     }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -101,7 +101,7 @@ fn scan_installed_toolchains() -> Result<Vec<ToolchainInfo>> {
 
     for line in stdout.lines() {
         // rustup prints things like: "stable-x86_64-unknown-linux-gnu (active, default)"
-        if let Some(name) = line.trim().split_whitespace().next()
+        if let Some(name) = line.split_whitespace().next()
             && let Some(info) = inspect_toolchain(name)
         {
             available.push(info);

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -1,21 +1,44 @@
+use std::collections::BTreeSet;
 use std::process::Command;
 use std::sync::mpsc;
 use std::sync::mpsc::TryRecvError;
 use std::thread;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use esp_generate::template::{GeneratorOption, GeneratorOptionItem};
 
 use crate::{Chip, check};
 
+/// Chip-agnostic metadata for a single installed rustup toolchain.
+///
+/// Scanning this information is expensive (one `rustc +tc --print target-list`
+/// and one `rustc +tc --version` per toolchain), so we capture it once up front
+/// and then derive per-chip filtered views via [`toolchains_for_chip`] without
+/// spawning any more subprocesses.
+#[derive(Debug, Clone)]
+pub struct ToolchainInfo {
+    pub name: String,
+    pub targets: BTreeSet<String>,
+    pub version: Option<check::Version>,
+}
+
+/// The filtered list of toolchains usable for a given chip, alongside any
+/// non-fatal warnings the caller should surface (e.g. "`esp32` excluded because
+/// the requested CLI toolchain is generic").
+#[derive(Debug, Default)]
+pub struct FilteredToolchains {
+    pub names: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
 pub struct ToolchainScan {
-    rx: mpsc::Receiver<Result<Vec<String>>>,
-    cached: Option<Result<Vec<String>>>,
+    rx: mpsc::Receiver<Result<Vec<ToolchainInfo>>>,
+    cached: Option<Result<Vec<ToolchainInfo>>>,
 }
 
 impl ToolchainScan {
     /// Try to get the scanned toolchain list *without blocking*.
-    pub fn try_get_toolchain_list(&mut self) -> Option<&Result<Vec<String>>> {
+    pub fn try_get_toolchain_list(&mut self) -> Option<&Result<Vec<ToolchainInfo>>> {
         if self.cached.is_some() {
             return self.cached.as_ref();
         }
@@ -36,26 +59,25 @@ impl ToolchainScan {
         }
     }
 }
-/// Start discovering toolchains in a background thread.
-pub fn start_toolchain_scan(
-    chip: Chip,
-    cli_toolchain: Option<String>,
-    msrv: check::Version,
-) -> ToolchainScan {
+/// Start discovering all installed rustup toolchains in a background thread.
+///
+/// No chip or MSRV is involved here — the scan is chip-agnostic on purpose so
+/// that switching chips in the TUI does not require re-scanning. Per-chip
+/// filtering is done in-memory by [`toolchains_for_chip`].
+pub fn start_toolchain_scan() -> ToolchainScan {
     let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {
-        let cli_ref = cli_toolchain.as_deref();
-        let result = find_toolchains(chip, cli_ref, &msrv);
+        let result = scan_installed_toolchains();
         let _ = tx.send(result);
     });
 
     ToolchainScan { rx, cached: None }
 }
 
-/// Return all installed rustup toolchains that support the given `target`
-/// and meet the given MSRV.
-fn filter_toolchains_for(target: &str, msrv: &check::Version) -> Result<Vec<String>> {
+/// Enumerate every installed rustup toolchain and capture its target list and
+/// version. Never fails hard — subprocess errors degrade to "no toolchains".
+fn scan_installed_toolchains() -> Result<Vec<ToolchainInfo>> {
     let output = match Command::new("rustup").args(["toolchain", "list"]).output() {
         Ok(res) => res,
         Err(err) => {
@@ -78,27 +100,21 @@ fn filter_toolchains_for(target: &str, msrv: &check::Version) -> Result<Vec<Stri
     let mut available = Vec::new();
 
     for line in stdout.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-
         // rustup prints things like: "stable-x86_64-unknown-linux-gnu (active, default)"
-        let Some(name) = line.split_whitespace().next() else {
-            continue;
-        };
-
-        if toolchain_matches_target_and_msrv(name, target, msrv) {
-            available.push(name.to_string());
+        if let Some(name) = line.trim().split_whitespace().next()
+            && let Some(info) = inspect_toolchain(name)
+        {
+            available.push(info);
         }
     }
 
     Ok(available)
 }
 
-fn toolchain_matches_target_and_msrv(name: &str, target: &str, msrv: &check::Version) -> bool {
-    // check whether this toolchain's rustc knows the desired target
-    // (rustup doesn't recognize some custom toolchains, e.g. `esp`)
+/// Collect target list + version for a single toolchain. Returns `None` if the
+/// toolchain can't be introspected at all (e.g. not a real rustup toolchain —
+/// we skip rather than poison the whole scan).
+fn inspect_toolchain(name: &str) -> Option<ToolchainInfo> {
     let output = match Command::new("rustc")
         .args([
             format!("+{name}"),
@@ -110,7 +126,7 @@ fn toolchain_matches_target_and_msrv(name: &str, target: &str, msrv: &check::Ver
         Ok(res) => res,
         Err(err) => {
             log::warn!("Failed to run `rustc +{name} --print target-list`: {err}");
-            return false;
+            return None;
         }
     };
 
@@ -119,28 +135,25 @@ fn toolchain_matches_target_and_msrv(name: &str, target: &str, msrv: &check::Ver
             "`rustc +{name} --print target-list` exited with status {:?}",
             output.status.code()
         );
-        return false;
+        return None;
     }
 
-    if !String::from_utf8_lossy(&output.stdout)
+    let targets: BTreeSet<String> = String::from_utf8_lossy(&output.stdout)
         .lines()
-        .any(|l| l.trim() == target)
-    {
-        // target not found - skip
-        return false;
-    }
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect();
 
-    // call `rustc +<toolchain> --version` and compare to `msrv`
-    if let Some(ver) = check::get_version("rustc", &[&format!("+{name}")]) {
-        if !ver.is_at_least(msrv) {
-            // toolchain version is below MSRV - skip
-            return false;
-        }
-    } else {
+    let version = check::get_version("rustc", &[&format!("+{name}")]);
+    if version.is_none() {
         log::warn!("Failed to detect rustc version for toolchain `{name}`; skipping MSRV check");
     }
 
-    true
+    Some(ToolchainInfo {
+        name: name.to_string(),
+        targets,
+        version,
+    })
 }
 
 /// Return the currently active rustup toolchain name, if any
@@ -160,127 +173,171 @@ fn active_rustup_toolchain() -> Option<String> {
         .and_then(|line| line.split_whitespace().next().map(|name| name.to_string()))
 }
 
-/// Among all installed toolchains, finds ones that support the required target and satisfy the MSRV.
-pub(crate) fn find_toolchains(
+/// Pure, cheap filter over a [`ToolchainInfo`] slice for the given chip.
+///
+/// Recomputed on demand (e.g. whenever the user switches chip in the TUI).
+/// All per-chip concerns live here — target-triple match, MSRV gate, Xtensa
+/// exclusion of generic toolchains, and CLI-toolchain sort/validation — so
+/// that the cached scan data stays untouched across chip switches.
+///
+/// Previously-fatal CLI-toolchain mismatches are now returned as warnings:
+/// the caller decides whether to promote them (headless) or surface them in
+/// the TUI footer. Dynamic chip switching requires this: a chip switch that
+/// invalidates the CLI toolchain must not be unrecoverable.
+pub fn toolchains_for_chip(
+    all: &[ToolchainInfo],
     chip: Chip,
-    cli_toolchain: Option<&str>,
     msrv: &check::Version,
-) -> Result<Vec<String>> {
+    cli_hint: Option<&str>,
+) -> FilteredToolchains {
     let target = chip.metadata().target().to_string();
 
-    let mut available = filter_toolchains_for(&target, msrv)?;
+    let mut names: Vec<String> = all
+        .iter()
+        .filter(|tc| tc.targets.contains(target.as_str()))
+        .filter(|tc| tc.version.as_ref().is_none_or(|v| v.is_at_least(msrv)))
+        .map(|tc| tc.name.clone())
+        .collect();
 
     // for now, we should hide the generic toolchains for Xtensa (stable-*, beta-*, nightly-*).
     if chip.metadata().is_xtensa() {
-        available.retain(|name| {
+        names.retain(|name| {
             !(name.starts_with("stable") || name.starts_with("beta") || name.starts_with("nightly"))
         });
     }
 
-    // sanity check
-    if available.is_empty() {
-        if let Some(cli) = cli_toolchain {
-            if chip.metadata().is_xtensa()
-                && (cli.starts_with("stable")
-                    || cli.starts_with("beta")
-                    || cli.starts_with("nightly"))
-            {
-                bail!(
-                    "Toolchain `{cli}` is not supported for Xtensa targets; \
-                     please use different toolchain (e.g. `esp`, see  https://docs.espressif.com/projects/rust/book/getting-started/toolchain.html#xtensa-devices)"
-                );
-            }
+    let mut warnings = Vec::new();
 
-            bail!(
-                "Toolchain `{cli}` does not have target `{target}` installed (or no toolchain does).\
-                See https://docs.espressif.com/projects/rust/book/getting-started/toolchain.html"
-            );
+    if names.is_empty() {
+        if let Some(cli) = cli_hint {
+            if chip.metadata().is_xtensa() && is_generic_toolchain(cli) {
+                warnings.push(format!(
+                    "Toolchain `{cli}` is not supported for Xtensa targets; \
+                     please use different toolchain (e.g. `esp`, see \
+                     https://docs.espressif.com/projects/rust/book/getting-started/toolchain.html#xtensa-devices)"
+                ));
+            } else {
+                warnings.push(format!(
+                    "Toolchain `{cli}` does not have target `{target}` installed (or no toolchain does). \
+                     See https://docs.espressif.com/projects/rust/book/getting-started/toolchain.html"
+                ));
+            }
+        } else {
+            warnings.push(format!(
+                "No rustc toolchains found that have `{target}` installed; \
+                 toolchain category will stay as placeholder"
+            ));
         }
-        log::warn!(
-            "No rustc toolchains found that have `{target}` installed; toolchain category will stay as placeholder"
-        );
-        return Ok(Vec::new());
+        return FilteredToolchains { names, warnings };
     }
 
-    if let Some(cli) = cli_toolchain {
-        if !available.iter().any(|t| t == cli) {
-            if chip.metadata().is_xtensa()
-                && (cli.starts_with("stable")
-                    || cli.starts_with("beta")
-                    || cli.starts_with("nightly"))
-            {
-                bail!(
+    if let Some(cli) = cli_hint {
+        if !names.iter().any(|t| t == cli) {
+            if chip.metadata().is_xtensa() && is_generic_toolchain(cli) {
+                warnings.push(format!(
                     "Toolchain `{cli}` is not supported for Xtensa targets; \
                      please use an ESP toolchain (e.g. `esp`)"
-                );
+                ));
+            } else {
+                warnings.push(format!(
+                    "Toolchain `{cli}` does not have target `{target}` installed"
+                ));
             }
-
-            bail!("Toolchain `{cli}` does not have target `{target}` installed");
+        } else {
+            // CLI toolchain is valid: float it to the top for the selector.
+            names.sort();
+            names.sort_by_key(|t| if t == cli { 0 } else { 1 });
         }
-        // put CLI toolchain first in toolchain search in case it was provided.
-        available.sort();
-        available.sort_by_key(|t| if t == cli { 0 } else { 1 });
     }
-    Ok(available)
+
+    FilteredToolchains { names, warnings }
 }
 
-/// Rewrite the `toolchain` category using the provided `available` toolchains.
-pub(crate) fn populate_toolchain_category_from_list(
-    options: &mut [GeneratorOptionItem],
-    flat_options: &mut Vec<GeneratorOption>,
-    available: &[String],
-) -> Result<()> {
-    if available.is_empty() {
-        // nothing to do
-        return Ok(());
-    }
+fn is_generic_toolchain(name: &str) -> bool {
+    name.starts_with("stable") || name.starts_with("beta") || name.starts_with("nightly")
+}
 
-    // get active/default toolchain to mark it properly
-    let default = active_rustup_toolchain();
+/// Stash for the original "Scanning installed toolchains…" placeholder.
+///
+/// Captured once before any population and reused on every [`Self::populate`]
+/// call. This makes the populate step idempotent and reversible — crucial for
+/// dynamic chip switching, where a chip change may grow, shrink, or empty the
+/// list of valid toolchains. Mutating the placeholder in place (as the old API
+/// did) loses that anchor forever.
+#[derive(Debug, Clone)]
+pub struct ToolchainCategory {
+    placeholder: GeneratorOption,
+}
 
-    // rewrite the `toolchain` category using the placeholder option as template
-    for item in options.iter_mut() {
-        let GeneratorOptionItem::Category(category) = item else {
-            continue;
-        };
-        if category.name != "toolchain" {
-            continue;
-        }
-
-        // we know exactly the template/placeholder structure, so we can just take `first` one
-        let template_opt = match category.options.first() {
-            Some(GeneratorOptionItem::Option(opt)) => opt.clone(),
-            _ => {
-                // If `template.yaml` is broken, fail loudly
-                panic!("toolchain category must contain a placeholder !Option");
-            }
-        };
-
-        // remove the placeholder, we've "scanned" it already
-        category.options.clear();
-
-        for toolchain in available {
-            // copy our placeholder option (again) to populate another toolchain instead of it
-            let mut opt = template_opt.clone();
-
-            let is_default = default.as_deref() == Some(toolchain.as_str());
-
-            opt.name = toolchain.clone();
-            opt.display_name = if is_default {
-                format!("Use `{toolchain}` toolchain [default]")
-            } else {
-                format!("Use `{toolchain}` toolchain")
+impl ToolchainCategory {
+    /// Capture the placeholder option sitting under the `toolchain` category.
+    ///
+    /// Returns `None` if the template has no `toolchain` category at all; the
+    /// caller can choose to skip toolchain handling entirely in that case.
+    pub fn capture(options: &[GeneratorOptionItem]) -> Option<Self> {
+        for item in options {
+            let GeneratorOptionItem::Category(category) = item else {
+                continue;
             };
-            opt.selection_group = "toolchain".to_string();
-
-            category
-                .options
-                .push(GeneratorOptionItem::Option(opt.clone()));
-            flat_options.push(opt);
+            if category.name != "toolchain" {
+                continue;
+            }
+            let GeneratorOptionItem::Option(first) = category.options.first()? else {
+                return None;
+            };
+            return Some(Self {
+                placeholder: first.clone(),
+            });
         }
-
-        break;
+        None
     }
 
-    Ok(())
+    /// Rebuild the `toolchain` category wholesale from `available`.
+    ///
+    /// - Empty `available` leaves / restores the placeholder row, so the
+    ///   "Scanning installed toolchains…" text reappears if a chip switch
+    ///   wipes the list.
+    /// - Non-empty `available` replaces the category with one option per
+    ///   discovered toolchain, each derived from the stashed placeholder
+    ///   (so `selection_group` / help text stay consistent with the YAML).
+    ///
+    /// The caller is responsible for rebuilding dependent state after this:
+    /// in particular [`crate::config::ActiveConfiguration::rebuild_indices`]
+    /// must be invoked on any live `ActiveConfiguration` whose `options` were
+    /// mutated, or `selected` indices will dangle.
+    pub fn populate(&self, options: &mut [GeneratorOptionItem], available: &[String]) {
+        let default = active_rustup_toolchain();
+
+        for item in options.iter_mut() {
+            let GeneratorOptionItem::Category(category) = item else {
+                continue;
+            };
+            if category.name != "toolchain" {
+                continue;
+            }
+
+            category.options.clear();
+
+            if available.is_empty() {
+                category
+                    .options
+                    .push(GeneratorOptionItem::Option(self.placeholder.clone()));
+                return;
+            }
+
+            for toolchain in available {
+                let mut opt = self.placeholder.clone();
+                let is_default = default.as_deref() == Some(toolchain.as_str());
+                opt.name = toolchain.clone();
+                opt.display_name = if is_default {
+                    format!("Use `{toolchain}` toolchain [default]")
+                } else {
+                    format!("Use `{toolchain}` toolchain")
+                };
+                opt.selection_group = "toolchain".to_string();
+                category.options.push(GeneratorOptionItem::Option(opt));
+            }
+            return;
+        }
+    }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -59,6 +59,43 @@ impl Repository {
         }
     }
 
+    /// Rebuild the options tree for a (possibly different) chip.
+    ///
+    /// The `options` argument is the *fully prepared* tree: the caller is
+    /// responsible for running chip-filtering, module population and toolchain
+    /// population against a pristine template. This keeps `Repository` free of
+    /// chip-specific knowledge — it only owns the mechanical "my tree changed,
+    /// keep my state consistent" primitive.
+    ///
+    /// The menu path is trimmed to the depth that still resolves against the
+    /// new tree rather than reset wholesale, so callers that repopulate a
+    /// single category on the *same* chip (notably the toolchain scan) keep
+    /// their cursor where it is; callers that truly switch chips typically
+    /// want to [`Self::reset_path`] after this.
+    pub fn set_options(&mut self, chip: Chip, options: Vec<GeneratorOptionItem>) {
+        self.config.reset_options(chip, options);
+
+        // Trim the navigation path to whatever still resolves in the new tree.
+        let mut current: &[GeneratorOptionItem] = &self.config.options;
+        let mut valid_depth = 0;
+        for &idx in &self.path {
+            match current.get(idx) {
+                Some(GeneratorOptionItem::Category(category)) => {
+                    valid_depth += 1;
+                    current = category.options.as_slice();
+                }
+                _ => break,
+            }
+        }
+        self.path.truncate(valid_depth);
+    }
+
+    /// Collapse the menu path back to the root. Intended for callers that have
+    /// just switched chip and want the UI to start from a known location.
+    pub fn reset_path(&mut self) {
+        self.path.clear();
+    }
+
     /// Returns the *explicitly* selected toolchain, if there is any
     fn selected_toolchain(&self) -> Option<String> {
         self.config.selected.iter().find_map(|idx| {
@@ -726,6 +763,71 @@ mod test {
             wide_text.contains("will disable: loooooong-one, loooooong-two, loooooong-three"),
             "expected detailed trailer, got: {wide_text:?}"
         );
+    }
+
+    #[test]
+    fn set_options_preserves_survivors_drops_missing_and_cascades() {
+        // Rebuilding the options tree (e.g. on chip switch) must:
+        //   * keep selections whose option name survives in the new tree,
+        //   * drop selections whose option was removed (remap-by-name),
+        //   * cascade out anything whose requirements are now unmet,
+        //   * trim `path` to whatever still resolves in the new tree.
+        let initial = vec![
+            GeneratorOptionItem::Category(esp_generate::template::GeneratorOptionCategory {
+                name: "cat".to_string(),
+                display_name: "cat".to_string(),
+                help: String::new(),
+                requires: Vec::new(),
+                options: vec![
+                    option("survivor", &[]),
+                    option("will-vanish", &[]),
+                    option("dependent", &["will-vanish"]),
+                ],
+            }),
+        ];
+
+        let mut repository = Repository::new(
+            Chip::Esp32,
+            initial,
+            &[
+                "survivor".to_string(),
+                "will-vanish".to_string(),
+                "dependent".to_string(),
+            ],
+        );
+        // Simulate the user having entered the `cat` category.
+        repository.enter_group(0);
+        assert_eq!(repository.path.len(), 1);
+
+        // New tree for a "different chip" — `will-vanish` is gone; the category
+        // itself is preserved so the path stays valid. `dependent` has its
+        // required option removed so it must cascade out.
+        let rebuilt = vec![
+            GeneratorOptionItem::Category(esp_generate::template::GeneratorOptionCategory {
+                name: "cat".to_string(),
+                display_name: "cat".to_string(),
+                help: String::new(),
+                requires: Vec::new(),
+                options: vec![option("survivor", &[]), option("dependent", &["will-vanish"])],
+            }),
+        ];
+
+        repository.set_options(Chip::Esp32c6, rebuilt);
+
+        assert_eq!(repository.config.chip, Chip::Esp32c6);
+        assert!(repository.config.is_selected("survivor"));
+        // Name no longer exists in the new tree: remap-by-name drops it.
+        assert!(!repository.config.is_selected("will-vanish"));
+        // Present but requirement unmet: cascade evicts it.
+        assert!(!repository.config.is_selected("dependent"));
+        // `cat` category still exists at the same index → path is preserved.
+        assert_eq!(repository.path.len(), 1);
+
+        // Now rebuild with the category itself gone: path must be trimmed.
+        let reshaped = vec![option("survivor", &[])];
+        repository.set_options(Chip::Esp32c6, reshaped);
+        assert_eq!(repository.path.len(), 0);
+        assert!(repository.config.is_selected("survivor"));
     }
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -147,6 +147,54 @@ impl Repository {
         current
     }
 
+    /// Tree-indices of the items that pass their `compatible` check at the
+    /// current menu level, in their original order.
+    ///
+    /// The menu renders and navigates over this filtered view so that items
+    /// failing their `compatible` constraint are invisible to the user — the
+    /// generalised replacement for the chip-level pruning that used to happen
+    /// at tree-build time. Row indices produced by ratatui's `ListState`
+    /// therefore index into `visible_indices()`, not into `current_level()`,
+    /// and every caller that needs the underlying tree item must translate via
+    /// [`Self::visible_item`].
+    fn visible_indices(&self) -> Vec<usize> {
+        let level = self.current_level();
+        level
+            .iter()
+            .enumerate()
+            .filter(|(_, v)| self.is_item_visible(v))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Translate a row index (as delivered by the TUI's `ListState`) into the
+    /// underlying item at the current level.
+    pub fn visible_item(&self, row: usize) -> &GeneratorOptionItem {
+        let level = self.current_level();
+        let tree_idx = self.visible_indices()[row];
+        &level[tree_idx]
+    }
+
+    /// Number of items currently visible at this level. The TUI renders
+    /// exactly this many rows.
+    pub fn visible_count(&self) -> usize {
+        self.visible_indices().len()
+    }
+
+    /// An item is visible in the TUI when:
+    ///   * for a plain option: its `compatible` constraint is satisfied —
+    ///     i.e. every referenced selection group has an allowed option active;
+    ///   * for a category: at least one of its children (recursively) is
+    ///     visible. An empty category — real or filtered — is hidden too.
+    fn is_item_visible(&self, item: &GeneratorOptionItem) -> bool {
+        match item {
+            GeneratorOptionItem::Option(option) => self.config.is_option_compatible(option),
+            GeneratorOptionItem::Category(category) => {
+                category.options.iter().any(|child| self.is_item_visible(child))
+            }
+        }
+    }
+
     /// Returns `true` if the current menu level is inside a category called `name`.
     fn is_in_category(&self, name: &str) -> bool {
         if self.path.is_empty() {
@@ -196,16 +244,24 @@ impl Repository {
         }
     }
 
-    fn enter_group(&mut self, index: usize) {
-        self.path.push(index);
+    /// `row` is the index delivered by the TUI's `ListState`, i.e. a position
+    /// inside the filtered visible view. It's translated to the real tree
+    /// index before being pushed onto `path`.
+    fn enter_group(&mut self, row: usize) {
+        let tree_idx = self.visible_indices()[row];
+        self.path.push(tree_idx);
     }
 
-    fn toggle_current(&mut self, index: usize) {
+    /// `row` is a visible-row index (see [`Self::enter_group`]). Options in
+    /// the `chip` selection group behave as a radio — clicking the already-
+    /// selected chip is a no-op; switching chips goes through the usual
+    /// `select_idx` cascade.
+    fn toggle_current(&mut self, row: usize) {
         if !self.current_level_is_active() {
             return;
         }
 
-        let GeneratorOptionItem::Option(ref option) = self.current_level()[index] else {
+        let GeneratorOptionItem::Option(ref option) = *self.visible_item(row) else {
             ratatui::restore();
             unreachable!();
         };
@@ -234,8 +290,9 @@ impl Repository {
         }
     }
 
-    fn is_option(&self, index: usize) -> bool {
-        matches!(self.current_level()[index], GeneratorOptionItem::Option(_))
+    /// `row` is a visible-row index (see [`Self::enter_group`]).
+    fn is_option(&self, row: usize) -> bool {
+        matches!(self.visible_item(row), GeneratorOptionItem::Option(_))
     }
 
     fn up(&mut self) {
@@ -258,10 +315,22 @@ impl Repository {
         let level = self.current_level();
         let level_active = self.current_level_is_active();
 
-        level
+        // Iterate the *visible* view only: items whose `compatible` constraint
+        // currently fails are hidden from the TUI as part of the cascade, and
+        // their stale selections (if any) have already been cleared by
+        // `drop_unsatisfied`. `idx` is the row index handed back to the
+        // `ListState`, which is why every navigation helper translates through
+        // `Self::visible_indices` before touching the real tree.
+        let visible: Vec<(usize, &GeneratorOptionItem)> = level
             .iter()
             .enumerate()
-            .map(|(idx, v)| {
+            .filter(|(_, v)| self.is_item_visible(v))
+            .collect();
+
+        visible
+            .iter()
+            .enumerate()
+            .map(|(idx, &(_, v))| {
                 let is_selected = self
                     .config
                     .selected
@@ -586,6 +655,7 @@ mod test {
     use super::Repository;
     use crate::Chip;
     use esp_generate::template::{GeneratorOption, GeneratorOptionItem};
+    use indexmap::IndexMap;
 
     fn option(name: &str, requires: &[&str]) -> GeneratorOptionItem {
         GeneratorOptionItem::Option(GeneratorOption {
@@ -594,18 +664,27 @@ mod test {
             selection_group: String::new(),
             help: String::new(),
             requires: requires.iter().map(|r| r.to_string()).collect(),
-            chips: Vec::new(),
+            compatible: IndexMap::new(),
         })
     }
 
+    /// Build an option that is only compatible with the given chips. The
+    /// `compatible` map uses the `chip` selection group as its key, which is
+    /// the generalisation of the old `chips: [...]` field — callers still
+    /// just pass a `&[Chip]` for convenience.
     fn option_for_chips(name: &str, requires: &[&str], chips: &[Chip]) -> GeneratorOptionItem {
+        let mut compatible = IndexMap::new();
+        compatible.insert(
+            "chip".to_string(),
+            chips.iter().map(|c| c.to_string()).collect(),
+        );
         GeneratorOptionItem::Option(GeneratorOption {
             name: name.to_string(),
             display_name: name.to_string(),
             selection_group: String::new(),
             help: String::new(),
             requires: requires.iter().map(|r| r.to_string()).collect(),
-            chips: chips.to_vec(),
+            compatible,
         })
     }
 
@@ -618,7 +697,7 @@ mod test {
             selection_group: "chip".to_string(),
             help: String::new(),
             requires: Vec::new(),
-            chips: Vec::new(),
+            compatible: IndexMap::new(),
         })
     }
 
@@ -756,43 +835,83 @@ mod test {
             );
         }
 
-        // Non-toggleable rows must stay silent even when `would_force_deselect`
-        // would otherwise report evictions — a user can't actually toggle the
-        // row, so advertising a phantom cascade is misleading.
+        // Visible-but-non-toggleable rows must stay silent even when
+        // `would_force_deselect` would otherwise report evictions — a user
+        // can't actually toggle the row, so advertising a phantom cascade is
+        // misleading. `unmet-pos` has an unmet positive requirement but its
+        // `compatible` constraint is trivially satisfied, so it still renders.
         //
-        // Two shapes are exercised:
-        //   * `unmet-pos`  — positive requirement not satisfied (`needs-x`).
-        //   * `wrong-chip` — chip-mismatch; `requires: ["!method"]` would still
-        //     return a cascade from the raw predicate, so only the gate keeps
-        //     the row quiet.
+        // (The `compatible` failure case is exercised separately below —
+        // those rows are now HIDDEN from the TUI entirely, not shown silent.)
         let options = vec![
             option("method", &[]),
             option("unmet-pos", &["needs-x", "!method"]),
-            option_for_chips("wrong-chip", &["!method"], &[Chip::Esp32c6]),
         ];
-        let repository =
-            Repository::new(Chip::Esp32, options, &["method".to_string()]);
+        let repository = Repository::new(Chip::Esp32, options, &["method".to_string()]);
 
-        for idx in 1..=2 {
-            let (actionable, line) = repository
-                .current_level_desc(80, &ui, Some(idx))
-                .into_iter()
-                .nth(idx)
-                .unwrap();
-            let text: String = line
-                .spans
-                .iter()
-                .map(|s| s.content.to_string())
-                .collect();
-            assert!(
-                !actionable,
-                "row {idx} must report as non-actionable, got: {text:?}"
-            );
-            assert!(
-                !text.contains("will disable"),
-                "non-toggleable hovered row {idx} must not show the warning, got: {text:?}"
-            );
-        }
+        let (actionable, line) = repository
+            .current_level_desc(80, &ui, Some(1))
+            .into_iter()
+            .nth(1)
+            .unwrap();
+        let text: String = line
+            .spans
+            .iter()
+            .map(|s| s.content.to_string())
+            .collect();
+        assert!(
+            !actionable,
+            "unmet-pos row must report as non-actionable, got: {text:?}"
+        );
+        assert!(
+            !text.contains("will disable"),
+            "non-toggleable hovered row must not show the warning, got: {text:?}"
+        );
+
+        // Incompatible rows are now hidden from the TUI by
+        // `current_level_desc` — they don't even enter the visible list, so
+        // `will disable` is impossible to render. This is the generalised
+        // replacement for the old "chip-mismatch shown as a silent, greyed-out
+        // row" behaviour: `compatible: { chip: [esp32c6] }` with an `esp32`
+        // active in the chip selection group filters the row out outright.
+        let mut wrong_chip_compat = IndexMap::new();
+        wrong_chip_compat.insert("chip".to_string(), vec!["esp32c6".to_string()]);
+        let options = vec![
+            // Stand-in for the runtime chip selector category.
+            chip_group_option(Chip::Esp32),
+            option("method", &[]),
+            GeneratorOptionItem::Option(GeneratorOption {
+                name: "wrong-chip".to_string(),
+                display_name: "wrong-chip".to_string(),
+                selection_group: String::new(),
+                help: String::new(),
+                requires: vec!["!method".to_string()],
+                compatible: wrong_chip_compat,
+            }),
+        ];
+        let repository = Repository::new(
+            Chip::Esp32,
+            options,
+            &["esp32".to_string(), "method".to_string()],
+        );
+        let rows = repository.current_level_desc(80, &ui, Some(0));
+        assert!(
+            rows.iter()
+                .all(|(_, line)| !line.spans.iter().any(|s| s.content.contains("wrong-chip"))),
+            "incompatible row must be hidden from current_level_desc, got rows: {:?}",
+            rows.iter()
+                .map(|(_, l)| l
+                    .spans
+                    .iter()
+                    .map(|s| s.content.to_string())
+                    .collect::<String>())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            rows.len(),
+            2,
+            "expected the chip-group option and `method` to remain visible"
+        );
     }
 
     #[test]
@@ -1146,10 +1265,7 @@ impl App {
 
                         if self.repository.is_option(selected) {
                             self.repository.toggle_current(selected);
-                        } else if !self.repository.current_level()[selected]
-                            .options()
-                            .is_empty()
-                        {
+                        } else if !self.repository.visible_item(selected).options().is_empty() {
                             self.repository.enter_group(self.selected());
                             self.enter_menu();
                         }
@@ -1255,12 +1371,11 @@ impl App {
         if let Some(current_state) = self.state.last_mut() {
             // Create a List from all list items and highlight the currently selected one
 
-            let current_item_active = if let Some(current) =
-                current_state.selected().and_then(|idx| {
-                    self.repository
-                        .current_level()
-                        .get(idx.min(items.len() - 1))
-                }) {
+            let current_item_active = if items.is_empty() {
+                false
+            } else if let Some(idx) = current_state.selected() {
+                let row = idx.min(items.len() - 1);
+                let current = self.repository.visible_item(row);
                 self.repository.current_level_is_active()
                     && self.repository.is_item_actionable(current)
             } else {
@@ -1283,10 +1398,12 @@ impl App {
     }
 
     fn help_paragraph(&self) -> Option<Paragraph<'_>> {
-        let selected = self
-            .selected()
-            .min(self.repository.current_level().len() - 1);
-        let option = &self.repository.current_level()[selected];
+        let visible_count = self.repository.visible_count();
+        if visible_count == 0 {
+            return None;
+        }
+        let selected = self.selected().min(visible_count - 1);
+        let option = self.repository.visible_item(selected);
 
         let relationships = self.repository.config.collect_relationships(option);
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -108,6 +108,32 @@ impl Repository {
         })
     }
 
+    /// Returns the chip that is currently ticked in the `chip` selection
+    /// group, if any. The main loop polls this after every event to detect
+    /// user-driven chip switches; disagreement with [`ActiveConfiguration::chip`]
+    /// triggers a full options-tree rebuild.
+    ///
+    /// Returns `None` only in degenerate situations (e.g. tests that build a
+    /// `Repository` without a chip category). Callers should fall back to
+    /// `self.config.chip` in that case.
+    pub fn selected_chip(&self) -> Option<Chip> {
+        self.config.selected.iter().find_map(|idx| {
+            let option = &self.config.flat_options[*idx];
+            if option.selection_group == "chip" {
+                option.name.parse().ok()
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Current depth of the menu navigation path. Used by `App` to keep its
+    /// `ListState` stack synchronized with `Repository::path` after a
+    /// `set_options` may have trimmed the path.
+    pub fn path_len(&self) -> usize {
+        self.path.len()
+    }
+
     fn current_level(&self) -> &[GeneratorOptionItem] {
         let mut current: &[GeneratorOptionItem] = &self.config.options;
 
@@ -185,6 +211,12 @@ impl Repository {
         };
 
         let option_name = option.name.clone();
+        // The chip group behaves like a required radio: there must always be
+        // exactly one chip ticked (the one backing the current options tree),
+        // so clicking the already-selected chip is a no-op instead of a
+        // deselect. Switching to a different chip still works through the
+        // usual selection_group mutex in `select_idx`.
+        let is_chip_group = option.selection_group == "chip";
 
         if let Some(i) = self
             .config
@@ -192,6 +224,9 @@ impl Repository {
             .iter()
             .position(|s| self.config.flat_options[*s].name == option_name)
         {
+            if is_chip_group {
+                return;
+            }
             let idx = self.config.selected[i];
             self.config.deselect_idx(idx);
         } else if self.config.is_option_toggleable(option) {
@@ -501,6 +536,41 @@ impl App {
     pub fn set_toolchains_loading(&mut self, loading: bool) {
         self.toolchains_loading = loading;
     }
+
+    /// Swap the repository's options tree and keep the UI state consistent.
+    ///
+    /// `Repository::set_options` trims the navigation path to whatever still
+    /// resolves in the new tree; we mirror that here on the `ListState` stack.
+    /// When the caller asks for a path reset (the typical chip-switch case),
+    /// we also collapse back to the root menu with a fresh selection at the
+    /// top so the user isn't dropped inside a now-unrelated category.
+    pub fn set_options(
+        &mut self,
+        chip: Chip,
+        options: Vec<GeneratorOptionItem>,
+        reset_path: bool,
+    ) {
+        self.repository.set_options(chip, options);
+        if reset_path {
+            self.repository.reset_path();
+        }
+
+        // The state stack is always `path_len + 1` — one for the root level,
+        // one per entered category. Truncate mirrors the path trim; the min-1
+        // floor guarantees we always have a state for the visible level.
+        let desired = self.repository.path_len() + 1;
+        self.state.truncate(desired.max(1));
+        if self.state.is_empty() {
+            let mut fresh = ListState::default();
+            fresh.select(Some(0));
+            self.state.push(fresh);
+        }
+        if reset_path
+            && let Some(last) = self.state.last_mut()
+        {
+            last.select(Some(0));
+        }
+    }
     pub fn selected_options(&self) -> Vec<String> {
         self.repository
             .config
@@ -536,6 +606,19 @@ mod test {
             help: String::new(),
             requires: requires.iter().map(|r| r.to_string()).collect(),
             chips: chips.to_vec(),
+        })
+    }
+
+    /// Build an option belonging to the `chip` selection group, mirroring what
+    /// the in-tree chip selector category looks like at runtime.
+    fn chip_group_option(chip: Chip) -> GeneratorOptionItem {
+        GeneratorOptionItem::Option(GeneratorOption {
+            name: chip.to_string(),
+            display_name: chip.to_string(),
+            selection_group: "chip".to_string(),
+            help: String::new(),
+            requires: Vec::new(),
+            chips: Vec::new(),
         })
     }
 
@@ -828,6 +911,196 @@ mod test {
         repository.set_options(Chip::Esp32c6, reshaped);
         assert_eq!(repository.path.len(), 0);
         assert!(repository.config.is_selected("survivor"));
+    }
+
+    #[test]
+    fn selected_chip_reports_chip_group_selection() {
+        // `selected_chip` is the bridge the main loop uses to notice user-driven
+        // chip switches. It must return the chip whose group entry is currently
+        // ticked, regardless of what `config.chip` says (divergence is the
+        // whole point — that's how we detect a pending switch), and `None`
+        // when no chip-group option is present in the tree at all.
+        let options = vec![
+            chip_group_option(Chip::Esp32),
+            chip_group_option(Chip::Esp32c6),
+            option("alloc", &[]),
+        ];
+
+        let repository = Repository::new(
+            Chip::Esp32,
+            options,
+            &["esp32c6".to_string(), "alloc".to_string()],
+        );
+
+        // config.chip still says Esp32 (the tree hasn't been rebuilt yet) but
+        // the user has ticked `esp32c6` in the chip group — the main loop
+        // picks this up and triggers the rebuild.
+        assert_eq!(repository.config.chip, Chip::Esp32);
+        assert_eq!(repository.selected_chip(), Some(Chip::Esp32c6));
+
+        // A tree without a chip category means no chip group selection —
+        // falls back to `None`, which the main loop maps to `config.chip`.
+        let no_chip_group = Repository::new(Chip::Esp32, vec![option("alloc", &[])], &[]);
+        assert_eq!(no_chip_group.selected_chip(), None);
+    }
+
+    #[test]
+    fn toggle_chip_group_is_a_radio_not_a_toggle() {
+        // The chip selection group is a *required* radio: clicking the
+        // currently-selected chip must be a no-op (there is no "no chip"
+        // state the options tree can be in). Clicking a different chip
+        // swaps via the normal selection_group mutex in `select_idx`.
+        let options = vec![
+            chip_group_option(Chip::Esp32),
+            chip_group_option(Chip::Esp32c6),
+        ];
+        let mut repository =
+            Repository::new(Chip::Esp32, options, &["esp32".to_string()]);
+
+        repository.toggle_current(0);
+        assert!(
+            repository.config.is_selected("esp32"),
+            "clicking the already-selected chip must be a no-op"
+        );
+
+        repository.toggle_current(1);
+        assert!(
+            repository.config.is_selected("esp32c6"),
+            "clicking a different chip must swap the selection"
+        );
+        assert!(
+            !repository.config.is_selected("esp32"),
+            "same-group mutex must deselect the previous chip"
+        );
+    }
+
+    #[test]
+    fn chip_switch_preview_lists_incompatible_options() {
+        // Hovering a different chip must preview the full blast radius of
+        // the impending switch, not just the same-group eviction of the
+        // current chip entry. Anything whose `chips` filter excludes the
+        // target chip would be removed from the tree by
+        // `remove_incompatible_chip_options` on rebuild — from the user's
+        // perspective that's a force-deselect, so it belongs in the
+        // "will disable" trailer.
+        let options = vec![
+            chip_group_option(Chip::Esp32),
+            chip_group_option(Chip::Esp32c6),
+            // Chip-specific options selected on the current chip.
+            option_for_chips("wroom", &[], &[Chip::Esp32]),
+            option_for_chips("another-esp32-only", &[], &[Chip::Esp32]),
+            // Chip-agnostic: must NOT appear in the preview.
+            option("alloc", &[]),
+            // Cascade target: requires `wroom`, which the switch drops, so
+            // this must be listed too (indirect fallout).
+            option("depends-on-wroom", &["wroom"]),
+        ];
+
+        let repository = Repository::new(
+            Chip::Esp32,
+            options,
+            &[
+                "esp32".to_string(),
+                "wroom".to_string(),
+                "another-esp32-only".to_string(),
+                "alloc".to_string(),
+                "depends-on-wroom".to_string(),
+            ],
+        );
+
+        // Look up the esp32c6 chip-group option as a plain `GeneratorOption`
+        // — `would_force_deselect` takes the unwrapped leaf.
+        let esp32c6 = match &repository.current_level()[1] {
+            GeneratorOptionItem::Option(o) => o.clone(),
+            _ => panic!("expected chip-group option"),
+        };
+
+        let evicted = repository.config.would_force_deselect(&esp32c6);
+
+        // Chip-incompatible options appear directly.
+        assert!(
+            evicted.iter().any(|n| n == "wroom"),
+            "expected `wroom` in preview, got: {evicted:?}"
+        );
+        assert!(
+            evicted.iter().any(|n| n == "another-esp32-only"),
+            "expected `another-esp32-only` in preview, got: {evicted:?}"
+        );
+        // The chip-group sibling (the currently selected chip) appears too —
+        // that's the same-group mutex kicking in.
+        assert!(
+            evicted.iter().any(|n| n == "esp32"),
+            "expected the old chip entry in preview, got: {evicted:?}"
+        );
+        // Indirect fallout via cascade.
+        assert!(
+            evicted.iter().any(|n| n == "depends-on-wroom"),
+            "expected cascade victim `depends-on-wroom` in preview, got: {evicted:?}"
+        );
+        // Chip-agnostic options survive the switch.
+        assert!(
+            !evicted.iter().any(|n| n == "alloc"),
+            "chip-agnostic options must not be listed, got: {evicted:?}"
+        );
+    }
+
+    #[test]
+    fn chip_switch_via_set_options_drops_incompatible_survivors() {
+        // Simulates what main.rs does when the user picks a different chip
+        // in the TUI: build a fresh tree for the new chip (which drops
+        // options tagged for other chips) and feed it through `set_options`.
+        //
+        // The `chips`-based filter is structural: incompatible options are
+        // *removed* from the new tree, so `rebuild_indices` drops them by
+        // name on the way through. This is exactly what we want — options
+        // the user had selected but that don't exist on the new chip simply
+        // vanish from `selected`.
+        let initial = vec![
+            chip_group_option(Chip::Esp32),
+            chip_group_option(Chip::Esp32c6),
+            // Only valid on the first chip.
+            option_for_chips("only-on-esp32", &[], &[Chip::Esp32]),
+            // Valid on both — should survive the switch.
+            option_for_chips("shared", &[], &[Chip::Esp32, Chip::Esp32c6]),
+        ];
+
+        let mut repository = Repository::new(
+            Chip::Esp32,
+            initial,
+            &[
+                "esp32".to_string(),
+                "only-on-esp32".to_string(),
+                "shared".to_string(),
+            ],
+        );
+
+        // Rebuild for the new chip as if `build_options_for_chip(Esp32c6, …)`
+        // had been called: `only-on-esp32` is gone, the chip group still
+        // carries both entries (it's chip-agnostic), and the user has now
+        // ticked `esp32c6`.
+        let rebuilt = vec![
+            chip_group_option(Chip::Esp32),
+            chip_group_option(Chip::Esp32c6),
+            option_for_chips("shared", &[], &[Chip::Esp32, Chip::Esp32c6]),
+        ];
+        // Before applying `set_options`, mimic what `toggle_current` would
+        // have done: swap the chip-group pick on the *old* tree. This is the
+        // state the main loop sees when it reads `selected_chip()` and
+        // triggers the rebuild.
+        repository.toggle_current(1);
+        assert_eq!(repository.selected_chip(), Some(Chip::Esp32c6));
+
+        repository.set_options(Chip::Esp32c6, rebuilt);
+
+        assert_eq!(repository.config.chip, Chip::Esp32c6);
+        assert!(repository.config.is_selected("esp32c6"));
+        assert!(!repository.config.is_selected("esp32"));
+        assert!(repository.config.is_selected("shared"));
+        // Chip-filtered out of the tree entirely; rebuild-by-name drops it.
+        assert!(!repository.config.is_selected("only-on-esp32"));
+        // And `selected_chip()` now agrees with `config.chip` — no more
+        // pending switch.
+        assert_eq!(repository.selected_chip(), Some(repository.config.chip));
     }
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -302,7 +302,7 @@ impl Repository {
     /// Builds the visible list rows.
     ///
     /// `hovered` is the index of the currently highlighted row (what the cursor is
-    /// on). Only that row gets the "will disable: …" warning trailer (styled yellow)
+    /// on). Only that row gets the "will deselect: …" warning trailer (styled yellow)
     /// when a selection there would force-deselect something; every other row keeps
     /// its normal right-aligned name. This keeps the list quiet and surfaces the
     /// side-effect info only when the user is actually considering the action.
@@ -346,10 +346,10 @@ impl Repository {
                 };
 
                 // The option's internal name is always shown on the right; only the
-                // hovered row additionally appends a yellow " - will disable: …"
+                // hovered row additionally appends a yellow " - will deselect: …"
                 // clause when selecting it would force-deselect something. When the
                 // detailed list wouldn't fit, the clause degrades to
-                // " - will disable N" (count) before any actual truncation kicks in.
+                // " - will deselect N" (count) before any actual truncation kicks in.
                 let name_part: String = match v {
                     GeneratorOptionItem::Option(_) => v.name().to_string(),
                     GeneratorOptionItem::Category(_) => String::new(),
@@ -374,12 +374,12 @@ impl Repository {
                         if evicted.is_empty() {
                             None
                         } else {
-                            let detailed = format!(" - will disable: {}", evicted.join(", "));
+                            let detailed = format!(" - will deselect: {}", evicted.join(", "));
                             let budget = padding.saturating_sub(name_part.len());
                             if detailed.len() <= budget {
                                 Some(detailed)
                             } else {
-                                Some(format!(" - will disable {}", evicted.len()))
+                                Some(format!(" - will deselect {}", evicted.len()))
                             }
                         }
                     }
@@ -468,7 +468,7 @@ struct UiElements {
     selected: &'static str,
     unselected: &'static str,
     category: &'static str,
-    /// Style applied to the " - will disable …" hover clause.
+    /// Style applied to the " - will deselect …" hover clause.
     force_deselect_style: Style,
 }
 
@@ -754,7 +754,7 @@ mod test {
 
     #[test]
     fn force_deselect_trailer_appears_only_on_hovered_row() {
-        // The "will disable …" trailer must:
+        // The "will deselect …" trailer must:
         //  * only show on the hovered row (keeps the list quiet),
         //  * live in its own span so the theme can style it,
         //  * appear for BOTH directions — selecting a row that force-deselects
@@ -795,7 +795,7 @@ mod test {
         let method_hover = row_text(0, Some(0));
         assert!(
             method_hover.contains("method")
-                && method_hover.contains("- will disable: dependent"),
+                && method_hover.contains("- will deselect: dependent"),
             "expected deselect-side warning on selected hovered row, got: {method_hover:?}"
         );
 
@@ -804,7 +804,7 @@ mod test {
         let unselected_hover = row_text(1, Some(1));
         assert!(
             unselected_hover.contains("method-unselected-a")
-                && unselected_hover.contains("- will disable:")
+                && unselected_hover.contains("- will deselect:")
                 && unselected_hover.contains("method")
                 && unselected_hover.contains("dependent"),
             "expected select-side warning on hovered row, got: {unselected_hover:?}"
@@ -821,7 +821,7 @@ mod test {
         let warning_span = hover_line
             .spans
             .iter()
-            .find(|s| s.content.contains("will disable"))
+            .find(|s| s.content.contains("will deselect"))
             .expect("warning span");
         assert!(!warning_span.content.contains("method-unselected-a "));
 
@@ -830,7 +830,7 @@ mod test {
         for idx in 0..3 {
             let text = row_text(idx, Some(2 /* `dependent` — non-destructive */));
             assert!(
-                !text.contains("will disable"),
+                !text.contains("will deselect"),
                 "no row must show the warning when hover is non-destructive, got: {text:?}"
             );
         }
@@ -864,13 +864,13 @@ mod test {
             "unmet-pos row must report as non-actionable, got: {text:?}"
         );
         assert!(
-            !text.contains("will disable"),
+            !text.contains("will deselect"),
             "non-toggleable hovered row must not show the warning, got: {text:?}"
         );
 
         // Incompatible rows are now hidden from the TUI by
         // `current_level_desc` — they don't even enter the visible list, so
-        // `will disable` is impossible to render. This is the generalised
+        // `will deselect` is impossible to render. This is the generalised
         // replacement for the old "chip-mismatch shown as a silent, greyed-out
         // row" behaviour: `compatible: { chip: [esp32c6] }` with an `esp32`
         // active in the chip selection group filters the row out outright.
@@ -917,7 +917,7 @@ mod test {
     #[test]
     fn force_deselect_trailer_collapses_to_count_when_too_wide() {
         // With several long-named options being evicted and a narrow row, the
-        // detailed list must collapse to "will disable N" rather than overflow /
+        // detailed list must collapse to "will deselect N" rather than overflow /
         // truncate the text.
         let options = vec![
             option("m", &[]),
@@ -946,11 +946,11 @@ mod test {
             .collect::<Vec<_>>();
         let narrow_text: String = narrow[0].spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(
-            narrow_text.contains("will disable 3"),
+            narrow_text.contains("will deselect 3"),
             "expected count fallback, got: {narrow_text:?}"
         );
         assert!(
-            !narrow_text.contains("will disable:"),
+            !narrow_text.contains("will deselect:"),
             "detailed list must not be present when it doesn't fit, got: {narrow_text:?}"
         );
 
@@ -962,7 +962,7 @@ mod test {
             .collect::<Vec<_>>();
         let wide_text: String = wide[0].spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(
-            wide_text.contains("will disable: loooooong-one, loooooong-two, loooooong-three"),
+            wide_text.contains("will deselect: loooooong-one, loooooong-two, loooooong-three"),
             "expected detailed trailer, got: {wide_text:?}"
         );
     }
@@ -1101,7 +1101,7 @@ mod test {
         // target chip would be removed from the tree by
         // `remove_incompatible_chip_options` on rebuild — from the user's
         // perspective that's a force-deselect, so it belongs in the
-        // "will disable" trailer.
+        // "will deselect" trailer.
         let options = vec![
             chip_group_option(Chip::Esp32),
             chip_group_option(Chip::Esp32c6),
@@ -1348,7 +1348,7 @@ impl App {
         outer_block.render(outer_area, buf);
 
         // The hovered index is what ratatui's ListState reports as selected; rows
-        // build their "will disable …" trailer only for this row so the list stays
+        // build their "will deselect …" trailer only for this row so the list stays
         // quiet otherwise.
         let hovered = self.state.last().and_then(|s| s.selected());
 

--- a/template/template.yaml
+++ b/template/template.yaml
@@ -1,6 +1,16 @@
 #INCLUDEFILE false
 options:
   - !Category
+    name: chip
+    display_name: Chip selection
+    help: Target Espressif chip. Switching chip rebuilds the option tree and drops any options that are incompatible with the new chip.
+    options:
+      - !Option
+        name: PLACEHOLDER
+        display_name: "<dynamic - will be replaced at runtime>"
+        selection_group: chip
+
+  - !Category
     name: module
     display_name: Module/Board selection
     help: Select your specific ESP32 module. This selection is optional, but it will generate code to help you avoid using reserved GPIOs.

--- a/template/template.yaml
+++ b/template/template.yaml
@@ -3,7 +3,8 @@ options:
   - !Category
     name: chip
     display_name: Chip selection
-    help: Target Espressif chip. Switching chip rebuilds the option tree and drops any options that are incompatible with the new chip.
+    help: Target Espressif chip. Switching chip hides options whose `compatible` allow-list
+      excludes the new chip and clears their selection.
     options:
       - !Option
         name: PLACEHOLDER
@@ -38,15 +39,16 @@ options:
     requires:
       - alloc
       - unstable-hal
-    chips:
-      - esp32
-      - esp32c2
-      - esp32c3
-      - esp32c5
-      - esp32c6
-      - esp32c61
-      - esp32s2
-      - esp32s3
+    compatible:
+      chip:
+        - esp32
+        - esp32c2
+        - esp32c3
+        - esp32c5
+        - esp32c6
+        - esp32c61
+        - esp32s2
+        - esp32s3
 
   - !Option
     name: ble-bleps
@@ -56,15 +58,16 @@ options:
     requires:
       - alloc
       - unstable-hal
-    chips:
-      - esp32
-      - esp32c2
-      - esp32c3
-      - esp32c5
-      - esp32c6
-      - esp32c61
-      - esp32h2
-      - esp32s3
+    compatible:
+      chip:
+        - esp32
+        - esp32c2
+        - esp32c3
+        - esp32c5
+        - esp32c6
+        - esp32c61
+        - esp32h2
+        - esp32s3
 
   - !Option
     name: ble-trouble
@@ -75,15 +78,16 @@ options:
       - alloc
       - unstable-hal
       - embassy
-    chips:
-      - esp32
-      - esp32c2
-      - esp32c3
-      - esp32c5
-      - esp32c6
-      - esp32c61
-      - esp32h2
-      - esp32s3
+    compatible:
+      chip:
+        - esp32
+        - esp32c2
+        - esp32c3
+        - esp32c5
+        - esp32c6
+        - esp32c61
+        - esp32h2
+        - esp32s3
 
   - !Option
     name: embassy
@@ -105,12 +109,13 @@ options:
     help: probe-rs is a debugger that connects to the chips over JTAG. It can be used to flash and
       monitor, and it can also be used to interactively debug an application, or run tests on the
       hardware. Semihosting or RTT-based technologies like defmt-rtt require probe-rs.
-    chips:
-      - esp32c5
-      - esp32c6
-      - esp32c61
-      - esp32h2
-      - esp32s3
+    compatible:
+      chip:
+        - esp32c5
+        - esp32c6
+        - esp32c61
+        - esp32h2
+        - esp32s3
 
   - !Option
     name: probe-rs
@@ -121,11 +126,12 @@ options:
 
       probe-rs requires a debug probe like esp-prog, and will not work with USB-UART adapters that
       often come on development boards.
-    chips:
-      - esp32
-      - esp32s2
-      - esp32c2
-      - esp32c3
+    compatible:
+      chip:
+        - esp32
+        - esp32s2
+        - esp32c2
+        - esp32c3
 
   - !Category
     name: flashing-probe-rs
@@ -179,13 +185,14 @@ options:
       - !Option
         name: wokwi
         display_name: Add support for Wokwi simulation using VS Code Wokwi extension.
-        chips:
-          - esp32
-          - esp32c3
-          - esp32c6
-          - esp32h2
-          - esp32s2
-          - esp32s3
+        compatible:
+          chip:
+            - esp32
+            - esp32c3
+            - esp32c6
+            - esp32h2
+            - esp32s2
+            - esp32s3
 
       - !Option
         name: ci

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,7 +11,7 @@ use esp_generate::{
     Chip,
     config::{ActiveConfiguration, find_option, flatten_options},
     modules::populate_module_category,
-    template::{GeneratorOptionCategory, GeneratorOptionItem, Template},
+    template::{GeneratorOption, GeneratorOptionCategory, GeneratorOptionItem, Template},
 };
 use itertools::Itertools;
 use log::info;
@@ -20,6 +20,21 @@ use log::info;
 const IGNORED_CATEGORIES: &[&str] = &["editor", "optional", "toolchain"];
 // The module selector generates way too many test cases to check with --all-combinations.
 const IGNORED_CATEGORIES_FULL: &[&str] = &["editor", "optional", "toolchain", "module"];
+
+/// Mirror of `esp_generate::main::prune_chip_incompatible_options`'s predicate:
+/// an option is considered chip-compatible when it either has no `compatible:
+/// { chip: [...] }` constraint at all, or its allow-list contains the given
+/// chip. Other `compatible` entries aren't evaluated here — like the binary,
+/// the xtask only applies chip-based filtering at the tree-shaping layer.
+fn is_chip_compatible(option: &GeneratorOption, chip: Chip) -> bool {
+    match option.compatible.get("chip") {
+        None => true,
+        Some(allowed) => {
+            let chip_name = chip.to_string();
+            allowed.iter().any(|n| n == &chip_name)
+        }
+    }
+}
 
 #[derive(Debug, Parser)]
 struct Cli {
@@ -255,7 +270,7 @@ fn options_for_chip(chip: Chip, all_combinations: bool) -> Result<Vec<Vec<String
         for option in &category.options {
             match option {
                 GeneratorOptionItem::Option(option) => {
-                    if option.chips.is_empty() || option.chips.contains(&chip) {
+                    if is_chip_compatible(option, chip) {
                         all_options.push(option.name.as_str());
                     }
                 }
@@ -279,7 +294,7 @@ fn options_for_chip(chip: Chip, all_combinations: bool) -> Result<Vec<Vec<String
             GeneratorOptionItem::Option(option) => {
                 if option.selection_group == "base-template" {
                     template_selectors.push(Some(option.name.clone()));
-                } else if option.chips.is_empty() || option.chips.contains(&chip) {
+                } else if is_chip_compatible(option, chip) {
                     all_options.push(option.name.as_str());
                 }
             }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,9 +17,9 @@ use itertools::Itertools;
 use log::info;
 
 // Unfortunate hard-coded list of non-codegen options.
-const IGNORED_CATEGORIES: &[&str] = &["editor", "optional", "toolchain"];
+const IGNORED_CATEGORIES: &[&str] = &["chip", "editor", "optional", "toolchain"];
 // The module selector generates way too many test cases to check with --all-combinations.
-const IGNORED_CATEGORIES_FULL: &[&str] = &["editor", "optional", "toolchain", "module"];
+const IGNORED_CATEGORIES_FULL: &[&str] = &["chip", "editor", "optional", "toolchain", "module"];
 
 /// Mirror of `esp_generate::main::prune_chip_incompatible_options`'s predicate:
 /// an option is considered chip-compatible when it either has no `compatible:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -425,12 +425,23 @@ fn generate(
 
     args.push(project_name.to_string());
 
-    Command::new("cargo")
+    // Capture stderr (rather than discarding it via `Stdio::null()`)
+    // so that any failure from the underlying `esp-generate` invocation — e.g.
+    // a bad option, a filesystem error, or a panic — surfaces to the xtask
+    // caller instead of silently turning into an empty project directory.
+    let output = Command::new("cargo")
         .args(args)
         .current_dir(workspace)
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
         .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.is_empty() {
+            eprintln!("{stderr}");
+        }
+        bail!("esp-generate failed for chip {chip} with options {options:?}");
+    }
 
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -258,13 +258,12 @@ fn options_for_chip(chip: Chip, all_combinations: bool) -> Result<Vec<Vec<String
     let options = include_str!("../../template/template.yaml");
     let mut template = serde_yaml::from_str::<Template>(options)?;
 
-    // Fully populate the template before deriving any test configuration: the
-    // `chip` and `module` categories ship as placeholder !Options in the YAML
-    // and are expanded at runtime, just like the binary does in
-    // `build_options_for_chip`. Populating `chip` is also what makes it
-    // possible to satisfy option-level `compatible: { chip: [...] }`
-    // constraints below by seeding the per-trial selection with the target
-    // chip's flat-option index.
+    // Fully populate the template before deriving any test configuration:
+    // both the `chip` and `module` categories ship as placeholder `!Option`
+    // entries in the YAML and are expanded at runtime, just like the binary
+    // does in `build_options_for_chip`. Without this, the chip-index lookup
+    // below would fail (and any option-level `compatible: { chip: [...] }`
+    // constraints would misfire during seeding).
     populate_chip_category(&mut template.options);
     populate_module_category(chip, &mut template.options);
     let flat_options = flatten_options(&template.options);
@@ -277,8 +276,9 @@ fn options_for_chip(chip: Chip, all_combinations: bool) -> Result<Vec<Vec<String
     // the compatibility predicate and silently drops out of the test matrix.
     //
     // The index is stripped back out before the selection list leaves this
-    // function so it doesn't surface as a spurious `-o <chip>` on the
-    // generated CLI; the chip is already passed via `--chip`.
+    // function: `generate()` injects the chip as its own `-o <chip>` entry,
+    // so leaving it in here would produce a duplicate `-o <chip>` on the
+    // generated CLI.
     let chip_name = chip.to_string();
     let chip_idx = flat_options
         .iter()
@@ -447,12 +447,16 @@ fn generate(
         "--no-default-features",
         "--",
         "--headless",
-        &format!("--chip={chip}"),
         &format!("--output-path={}", project_path.display()),
     ]
     .iter()
     .map(|arg| arg.to_string())
     .collect::<Vec<_>>();
+
+    // The target chip is now just another `-o` option as far as the
+    // `esp-generate` CLI is concerned; pass it first so it reads naturally
+    // in the log output (`WITH OPTIONS: …` lists the rest).
+    args.extend(["-o".to_string(), chip.to_string()]);
 
     for option in options {
         args.extend(["-o".to_string(), option.to_owned()]);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,7 @@ use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
 use esp_generate::{
     Chip,
+    chip_selector::populate_chip_category,
     config::{ActiveConfiguration, find_option, flatten_options},
     modules::populate_module_category,
     template::{GeneratorOption, GeneratorOptionCategory, GeneratorOptionItem, Template},
@@ -257,9 +258,34 @@ fn options_for_chip(chip: Chip, all_combinations: bool) -> Result<Vec<Vec<String
     let options = include_str!("../../template/template.yaml");
     let mut template = serde_yaml::from_str::<Template>(options)?;
 
-    // Populate the module category with chip-specific modules
+    // Fully populate the template before deriving any test configuration: the
+    // `chip` and `module` categories ship as placeholder !Options in the YAML
+    // and are expanded at runtime, just like the binary does in
+    // `build_options_for_chip`. Populating `chip` is also what makes it
+    // possible to satisfy option-level `compatible: { chip: [...] }`
+    // constraints below by seeding the per-trial selection with the target
+    // chip's flat-option index.
+    populate_chip_category(&mut template.options);
     populate_module_category(chip, &mut template.options);
     let flat_options = flatten_options(&template.options);
+
+    // Locate the flat index of the `chip`-group entry for the target chip.
+    // Every trial `ActiveConfiguration` below is seeded with this index so
+    // that `is_option_active` can satisfy option-level
+    // `compatible: { chip: [...] }` constraints — without it, every
+    // chip-restricted option (wifi, ble-*, chip-specific probe-rs, …) fails
+    // the compatibility predicate and silently drops out of the test matrix.
+    //
+    // The index is stripped back out before the selection list leaves this
+    // function so it doesn't surface as a spurious `-o <chip>` on the
+    // generated CLI; the chip is already passed via `--chip`.
+    let chip_name = chip.to_string();
+    let chip_idx = flat_options
+        .iter()
+        .position(|o| o.selection_group == "chip" && o.name == chip_name)
+        .ok_or_else(|| {
+            anyhow::anyhow!("template has no `chip` option named `{chip_name}`")
+        })?;
 
     fn collect<'data>(
         all_options: &mut Vec<&'data str>,
@@ -316,7 +342,7 @@ fn options_for_chip(chip: Chip, all_combinations: bool) -> Result<Vec<Vec<String
                 .unwrap_or_else(|| panic!("Option not found: {}", option));
             let mut config = ActiveConfiguration {
                 chip,
-                selected: vec![],
+                selected: vec![chip_idx],
                 flat_options: flat_options.clone(),
                 options: template.options.clone(),
             };
@@ -328,6 +354,7 @@ fn options_for_chip(chip: Chip, all_combinations: bool) -> Result<Vec<Vec<String
             enable_config_and_dependencies(&mut config, &option.name, chip)?;
 
             if is_valid(&config) {
+                config.selected.retain(|&idx| idx != chip_idx);
                 config.selected.sort();
                 available_options.push(config.selected);
             }
@@ -355,20 +382,28 @@ fn options_for_chip(chip: Chip, all_combinations: bool) -> Result<Vec<Vec<String
     let mut template_options = Some(template.options);
     let mut flat_options = Some(flat_options);
     for options in available_options.iter().map(|v| v.as_slice()).powerset() {
+        // Same reasoning as the single-option loop above: seed with the chip
+        // index so `is_valid` (which runs `is_option_active` per selected
+        // option) sees the `compatible.chip` allow-lists satisfied, then
+        // strip it back out before persisting the combination so the chip
+        // doesn't leak into the `-o` argument list.
+        let selected: Vec<usize> = options
+            .into_iter()
+            .flatten()
+            .chain(std::iter::once(&chip_idx))
+            .collect::<HashSet<_>>() // We don't need iteration order stability, slightly faster than `.unique()`
+            .into_iter()
+            .cloned()
+            .collect();
         let mut config = ActiveConfiguration {
             chip,
-            selected: options
-                .into_iter()
-                .flatten()
-                .collect::<HashSet<_>>() // We don't need iteration order stability, slightly faster than `.unique()`
-                .into_iter()
-                .cloned()
-                .collect(),
+            selected,
             options: template_options.take().unwrap(),
             flat_options: flat_options.take().unwrap(),
         };
 
         if is_valid(&config) {
+            config.selected.retain(|&idx| idx != chip_idx);
             config.selected.sort();
             result.push(config.selected);
         }


### PR DESCRIPTION
This PR reworks the chip selection process:

- `--chip` can still specify an initial selection, but
- The TUI has a chip row, that the user can use to select a chip
- Selecting a chip essentially reloads the ui, while keeping compatible options selected
- Template-wise, the compatibility check that may hide or show a config item can now use arbitrary config groups (TODO: rework flashing and async options)

The idea is that future external templates may not even have a chip option, so there is no point in having _special cased_ handling for them.