### PR TITLE
Replace special-casing `chip` with a `requires` list in template

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::Chip;
-
 use crate::template::{GeneratorOption, GeneratorOptionItem};
 
 #[derive(Debug)]
 pub struct ActiveConfiguration {
-    /// The chip that is configured for
-    pub chip: Chip,
     /// The names of the selected options
     pub selected: Vec<usize>,
     /// The tree of all available options
@@ -55,13 +51,13 @@ impl ActiveConfiguration {
             .collect();
     }
 
-    /// Swap in a new chip + options tree and keep `selected` / `flat_options`
+    /// Swap in a new options tree and keep `selected` / `flat_options`
     /// consistent.
     ///
-    /// This is the supported entry point for dynamic chip switching: the caller
-    /// builds the new options tree (chip filter + module population + toolchain
-    /// population) off of the pristine template and hands it over. The rest is
-    /// mechanical:
+    /// This is the supported entry point for dynamic tree rebuilds (chip
+    /// switch, toolchain scan result, …): the caller builds the new options
+    /// tree (chip filter + module population + toolchain population) off of
+    /// the pristine template and hands it over. The rest is mechanical:
     ///   * [`Self::rebuild_indices`] remaps selection indices by option name,
     ///     silently dropping any name that no longer exists in the new tree;
     ///   * [`Self::drop_unsatisfied`] then cascades out anything whose
@@ -70,11 +66,8 @@ impl ActiveConfiguration {
     ///     switch eliminated).
     ///
     /// Note: `path` on [`crate::tui::Repository`] is a UI concern and is NOT
-    /// touched here. Callers that change the chip should also either reset or
-    /// clamp the menu path themselves — the category the user was browsing may
-    /// no longer exist.
-    pub fn reset_options(&mut self, chip: Chip, options: Vec<GeneratorOptionItem>) {
-        self.chip = chip;
+    /// touched here.
+    pub fn reset_options(&mut self, options: Vec<GeneratorOptionItem>) {
         self.options = options;
         self.rebuild_indices();
         self.drop_unsatisfied();
@@ -172,7 +165,7 @@ impl ActiveConfiguration {
     }
 
     pub fn select(&mut self, option: &str) {
-        let (index, _o) = find_option(option, &self.flat_options, self.chip).unwrap();
+        let (index, _o) = find_option(option, &self.flat_options).unwrap();
         self.select_idx(index);
     }
 
@@ -282,7 +275,7 @@ impl ActiveConfiguration {
     /// toggleable (selecting it cascades the conflict out), and its cascade is
     /// exactly what callers want reported.
     pub fn would_force_deselect(&self, option: &GeneratorOption) -> Vec<String> {
-        let option_idx = find_option(&option.name, &self.flat_options, self.chip).map(|(i, _)| i);
+        let option_idx = find_option(&option.name, &self.flat_options).map(|(i, _)| i);
 
         let currently_selected = option_idx
             .map(|idx| self.selected.contains(&idx))
@@ -564,7 +557,7 @@ impl ActiveConfiguration {
 
     // An option can only be disabled if it's not required by any other selected option.
     pub fn can_be_disabled(&self, option: &str) -> bool {
-        let (option, _) = find_option(option, &self.flat_options, self.chip).unwrap();
+        let (option, _) = find_option(option, &self.flat_options).unwrap();
         Self::can_be_disabled_impl(&self.selected, &self.flat_options, option, false)
     }
 
@@ -636,34 +629,25 @@ pub struct Relationships<'a> {
     pub disabled_by: Vec<&'a str>,
 }
 
-/// Find an option by name, disambiguating duplicate entries via the `compatible`
-/// constraint on the `chip` selection group.
+/// Find an option by name.
 ///
-/// The template may legitimately carry two options that share a name but target
-/// different chips (e.g. the two `probe-rs` entries with different help text).
-/// We pick the first entry whose `compatible: { chip: [...] }` allow-list
-/// includes the given chip, or — if the entry doesn't constrain `chip` at all —
-/// the first such unconstrained entry.
+/// The template may carry multiple entries that share a name but differ by
+/// their `compatible: { chip: [...] }` constraint. `options` is expected to
+/// have already been pruned for the active chip (see
+/// `build_options_for_chip` in `main`), so at most one entry per name should
+/// survive and a simple name match is enough.
 pub fn find_option<'c>(
     option: &str,
     options: &'c [GeneratorOption],
-    chip: Chip,
 ) -> Option<(usize, &'c GeneratorOption)> {
-    let chip_name = chip.to_string();
-    options.iter().enumerate().find(|(_, opt)| {
-        if opt.name != option {
-            return false;
-        }
-        match opt.compatible.get("chip") {
-            None => true,
-            Some(allowed) => allowed.iter().any(|n| n == &chip_name),
-        }
-    })
+    options
+        .iter()
+        .enumerate()
+        .find(|(_, opt)| opt.name == option)
 }
 
 #[cfg(test)]
 mod test {
-    use crate::Chip;
     use indexmap::IndexMap;
 
     use crate::{
@@ -694,7 +678,6 @@ mod test {
             }),
         ];
         let active = ActiveConfiguration {
-            chip: Chip::Esp32,
             selected: vec![0],
             flat_options: flatten_options(&options),
             options,
@@ -741,7 +724,6 @@ mod test {
             }),
         ];
         let mut active = ActiveConfiguration {
-            chip: Chip::Esp32,
             selected: vec![],
             flat_options: flatten_options(&options),
             options,
@@ -810,7 +792,6 @@ mod test {
             }),
         ];
         let mut active = ActiveConfiguration {
-            chip: Chip::Esp32,
             selected: vec![],
             flat_options: flatten_options(&options),
             options,
@@ -859,7 +840,6 @@ mod test {
             }),
         ];
         let mut active = ActiveConfiguration {
-            chip: Chip::Esp32,
             selected: vec![],
             flat_options: flatten_options(&options),
             options,
@@ -898,7 +878,6 @@ mod test {
             }),
         ];
         let mut active = ActiveConfiguration {
-            chip: Chip::Esp32,
             selected: vec![],
             flat_options: flatten_options(&options),
             options,
@@ -976,7 +955,6 @@ mod test {
             }),
         ];
         let mut active = ActiveConfiguration {
-            chip: Chip::Esp32,
             selected: vec![],
             flat_options: flatten_options(&options),
             options,
@@ -1014,7 +992,7 @@ mod test {
         assert!(!evicted.contains(&"wifi".to_string())); // unrelated stays
 
         let (probe_rs_flat_idx, _) =
-            find_option("probe-rs", &active.flat_options, Chip::Esp32).unwrap();
+            find_option("probe-rs", &active.flat_options).unwrap();
         active.deselect_idx(probe_rs_flat_idx);
         assert!(!active.is_selected("probe-rs"));
         assert!(!active.is_selected("panic-rtt-target"));
@@ -1088,7 +1066,6 @@ mod test {
             }),
         ];
         let mut active = ActiveConfiguration {
-            chip: Chip::Esp32,
             selected: vec![],
             flat_options: flatten_options(&options),
             options,
@@ -1167,7 +1144,6 @@ mod test {
             }),
         ];
         let mut active = ActiveConfiguration {
-            chip: Chip::Esp32,
             selected: vec![],
             flat_options: flatten_options(&options),
             options,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::template::{GeneratorOption, GeneratorOptionItem};
 
@@ -93,30 +93,23 @@ impl ActiveConfiguration {
             .collect()
     }
 
-    /// Snapshot the currently-selected option (if any) for every selection
-    /// group referenced by some option's `compatible` map. The main loop
-    /// compares successive snapshots to decide when the options tree needs
-    /// a rebuild. Groups with no current selection map to an empty string.
-    pub fn compatibility_signature(&self) -> HashMap<String, String> {
-        let mut groups: HashSet<&str> = HashSet::new();
-        for opt in &self.flat_options {
-            for key in opt.compatible.keys() {
-                groups.insert(key.as_str());
-            }
-        }
-
+    /// For each group in `groups`, the currently-selected option name (or
+    /// empty string if none). `groups` must be collected from the pristine
+    /// template so that selections for groups whose dependants have been
+    /// pruned still show up.
+    pub fn compatibility_signature(&self, groups: &[String]) -> HashMap<String, String> {
         groups
-            .into_iter()
+            .iter()
             .map(|group| {
                 let selected = self
                     .selected
                     .iter()
                     .find_map(|&idx| {
                         let o = &self.flat_options[idx];
-                        (o.selection_group == group).then(|| o.name.clone())
+                        (&o.selection_group == group).then(|| o.name.clone())
                     })
                     .unwrap_or_default();
-                (group.to_string(), selected)
+                (group.clone(), selected)
             })
             .collect()
     }
@@ -632,10 +625,9 @@ pub struct Relationships<'a> {
 /// Find an option by name.
 ///
 /// The template may carry multiple entries that share a name but differ by
-/// their `compatible: { chip: [...] }` constraint. `options` is expected to
-/// have already been pruned for the active chip (see
-/// `build_options_for_chip` in `main`), so at most one entry per name should
-/// survive and a simple name match is enough.
+/// their `compatible` constraints. `options` is expected to have already been
+/// pruned for the active selections (see `build_options` in `main`), so at
+/// most one entry per name should survive and a simple name match is enough.
 pub fn find_option<'c>(
     option: &str,
     options: &'c [GeneratorOption],

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,26 @@ impl ActiveConfiguration {
         self.drop_unsatisfied();
     }
 
+    /// Return the subset of `required` that currently has no selected
+    /// option in the live tree. Mirrors
+    /// [`crate::template::Template::missing_required_groups`] but operates
+    /// on the selection indices the TUI actually mutates, so it stays in
+    /// sync across chip switches and toolchain repopulations without the
+    /// caller having to translate back to option names.
+    pub fn missing_required_groups(&self, required: &[String]) -> Vec<String> {
+        required
+            .iter()
+            .filter(|group| {
+                !self.selected.iter().any(|&idx| {
+                    self.flat_options
+                        .get(idx)
+                        .is_some_and(|o| &o.selection_group == *group)
+                })
+            })
+            .cloned()
+            .collect()
+    }
+
     pub fn is_group_selected(&self, group: &str) -> bool {
         self.selected
             .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+
 use crate::Chip;
 
 use crate::template::{GeneratorOption, GeneratorOptionItem};
@@ -95,6 +97,34 @@ impl ActiveConfiguration {
                 })
             })
             .cloned()
+            .collect()
+    }
+
+    /// Snapshot the currently-selected option (if any) for every selection
+    /// group referenced by some option's `compatible` map. The main loop
+    /// compares successive snapshots to decide when the options tree needs
+    /// a rebuild. Groups with no current selection map to an empty string.
+    pub fn compatibility_signature(&self) -> HashMap<String, String> {
+        let mut groups: HashSet<&str> = HashSet::new();
+        for opt in &self.flat_options {
+            for key in opt.compatible.keys() {
+                groups.insert(key.as_str());
+            }
+        }
+
+        groups
+            .into_iter()
+            .map(|group| {
+                let selected = self
+                    .selected
+                    .iter()
+                    .find_map(|&idx| {
+                        let o = &self.flat_options[idx];
+                        (o.selection_group == group).then(|| o.name.clone())
+                    })
+                    .unwrap_or_default();
+                (group.to_string(), selected)
+            })
             .collect()
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -517,7 +517,6 @@ fn main() -> Result<()> {
             required: TEMPLATE.required.clone(),
         },
         &args,
-        chip,
     )?;
 
     let mut initial_selected = args.option.clone();
@@ -1123,42 +1122,24 @@ fn process_file(
     Some(res)
 }
 
-fn process_options(template: &Template, args: &Args, chip: Option<Chip>) -> Result<()> {
+fn process_options(template: &Template, args: &Args) -> Result<()> {
     let mut success = true;
     // Two option catalogues, with complementary coverage:
-    //   - `populated_options` is the pruned, post-`build_options`
-    //     view: it DOES know about dynamically-populated entries (each
-    //     supported chip in the `chip` category, each module for the current
-    //     chip in the `module` category), but it has already been filtered
-    //     down to options compatible with the selected chip.
-    //   - `pristine_options` is the raw template: it lists every
-    //     chip-restricted option (so we can tell "pruned by chip" apart from
-    //     "unknown name"), but the `module` category still holds only its
-    //     literal `PLACEHOLDER` !Option.
-    // Options are looked up in the populated view first — anything present
-    // there is definitionally chip-compatible — and we only consult the
-    // pristine catalogue as a fallback so that chip-pruned names surface as
-    // "Not supported for chip …" rather than "Unknown option".
+    //   - `populated_options` is the pruned, post-`build_options` view: it
+    //     knows about dynamically-populated entries (module options, etc.)
+    //     but only those compatible with the current selections.
+    //   - `pristine_options` is the raw template: it lists every option
+    //     (including those pruned by `compatible`), so we can tell
+    //     "pruned by selection" apart from "unknown name".
     let populated_options = template.all_options();
     let pristine_options = TEMPLATE.all_options();
 
-    // Seed simulated selection with CLI `-o` plus the chip pick (when set)
-    // so `compatible: { chip: [...] }` constraints can be validated.
-    let chip_name = chip.map(|c| c.to_string());
     let flat_options = flatten_options(&template.options);
-    let mut selected: Vec<usize> = args
+    let selected: Vec<usize> = args
         .option
         .iter()
         .flat_map(|opt_name| flat_options.iter().position(|o| &o.name == opt_name))
         .collect();
-    if let Some(ref name) = chip_name
-        && let Some(pos) = flat_options
-            .iter()
-            .position(|o| o.selection_group == "chip" && &o.name == name)
-        && !selected.contains(&pos)
-    {
-        selected.push(pos);
-    }
 
     let selected_config = ActiveConfiguration {
         selected,
@@ -1168,26 +1149,14 @@ fn process_options(template: &Template, args: &Args, chip: Option<Chip>) -> Resu
 
     let mut same_selection_group: HashMap<&str, Vec<&str>> = HashMap::new();
 
-    // Iterate the user's CLI `-o` list directly rather than the resolved
-    // indices in `selected_config.selected`: an option that got pruned out
-    // of the chip-specific tree (because it isn't compatible with the
-    // selected chip) never makes it into `flat_options` and would be
-    // silently dropped here otherwise. We still want to surface a proper
-    // "Not supported for chip …" diagnostic in that case.
     for option in &args.option {
         let option = option.as_str();
-        let mut option_found = false;
-        let mut option_found_for_chip = false;
+        let mut option_found_populated = false;
+        let mut option_found_pristine = false;
 
-        // Primary lookup: the populated, chip-pruned view. Any match here is
-        // automatically both "known" and "compatible with the selected chip",
-        // and — for dynamically-populated names (module entries) — this is
-        // the only view that actually lists them by name.
         for &option_item in populated_options.iter().filter(|item| item.name == option) {
-            option_found = true;
-            option_found_for_chip = true;
+            option_found_populated = true;
 
-            // Is the option allowed to be selected?
             if selected_config.is_option_active(option_item) {
                 // Even if the option is active, another from the same selection group may be present.
                 // The TUI would deselect the previous option, but when specified from the command line,
@@ -1206,7 +1175,6 @@ fn process_options(template: &Template, args: &Args, chip: Option<Chip>) -> Resu
                 continue;
             }
 
-            // Something is wrong, print the constraints that are not met.
             success = false;
             let o = GeneratorOptionItem::Option(option_item.clone());
             let Relationships {
@@ -1231,40 +1199,28 @@ fn process_options(template: &Template, args: &Args, chip: Option<Chip>) -> Resu
             }
         }
 
-        // Fallback lookup: consult the pristine template only if the
-        // populated view didn't know the name, so that static options pruned
-        // out by chip compatibility are reported as "Not supported for chip
-        // …" rather than "Unknown option". Dynamic (module) names never
-        // appear here — but they'll always be found in the populated view
-        // above, so we don't need to special-case them.
-        if !option_found {
-            for &option_item in pristine_options.iter().filter(|item| item.name == option) {
-                option_found = true;
-
-                if let Some(allowed) = option_item.compatible.get("chip") {
-                    match chip_name.as_deref() {
-                        Some(name) if allowed.iter().any(|n| n == name) => {}
-                        _ => continue,
-                    }
-                }
-                option_found_for_chip = true;
-            }
+        if !option_found_populated {
+            option_found_pristine = pristine_options.iter().any(|item| item.name == option);
         }
 
-        if !option_found {
+        if !option_found_populated && !option_found_pristine {
             log::error!("Unknown option '{option}'");
             success = false;
-        } else if !option_found_for_chip {
-            match chip {
-                Some(c) => {
-                    log::error!("Option '{option}' is not supported for chip {c}");
-                }
-                None => {
-                    log::error!(
-                        "Option '{option}' has a chip-compatibility constraint but no chip was selected"
-                    );
-                }
-            }
+        } else if !option_found_populated {
+            let pristine = pristine_options
+                .iter()
+                .find(|item| item.name == option)
+                .unwrap();
+            let constraints = pristine
+                .compatible
+                .iter()
+                .map(|(group, allowed)| format!("{group} in [{}]", allowed.join(", ")))
+                .collect::<Vec<_>>()
+                .join("; ");
+            log::error!(
+                "Option '{option}' is not compatible with the current selection \
+                 (requires {constraints})"
+            );
             success = false;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,11 @@ impl SubCommands {
                     }
                 }
                 for (group, options) in groups {
-                    println!("Group: {}", group);
+                    if TEMPLATE.required.contains(group) {
+                        println!("Group: {} (required)", group);
+                    } else {
+                        println!("Group: {}", group);
+                    }
                     for option in options {
                         let option = &all_options[option];
                         let mut help_text = option.display_name.clone();
@@ -303,13 +307,18 @@ fn about() -> String {
 }
 
 /// Scan the user's `-o`/`--option` list for an entry that names a [`Chip`]
-/// variant. The chip is no longer a first-class CLI flag; it travels with the
-/// rest of the generation options, so `-o esp32c6` both picks the target and
-/// ticks the matching entry in the `chip` selection group.
+/// variant. The chip travels with the rest of the generation options (it's a
+/// normal entry in the `chip` selection group), so `-o esp32c6` both picks
+/// the target and ticks the matching option.
 ///
 /// Returns the first match. If the user passes multiple chip options (which
 /// is meaningless since they share a selection group), the conflict is
 /// surfaced later by [`process_options`] via the `same_selection_group` check.
+///
+/// Higher-level *presence* checks (i.e. "did the user pick a chip at all?")
+/// go through [`Template::missing_required_groups`] instead — this helper
+/// exists purely to produce the typed [`Chip`] value the rest of the
+/// generator pipeline consumes.
 fn chip_from_options(options: &[String]) -> Option<Chip> {
     options.iter().find_map(|opt| opt.parse::<Chip>().ok())
 }
@@ -319,10 +328,16 @@ fn setup_args_interactive(args: &mut Args) -> Result<()> {
         let mut missing = String::from(
             "You are in headless mode, but esp-generate needs more information to generate your project.",
         );
-        if chip_from_options(&args.option).is_none() {
-            missing.push_str(
-                "\nThe target chip is missing. Add `-o <your-chip-name>` (e.g. `-o esp32c6`) to the command.",
-            );
+        // Surface every required selection group that doesn't have a pick
+        // in `-o`, not just the chip. Templates declare their required
+        // groups in `template.yaml::required`; `chip` happens to be the
+        // only one today, but the generator doesn't hard-code that.
+        for group in TEMPLATE.missing_required_groups(&args.option) {
+            missing.push_str(&format!(
+                "\nNo option selected for the required `{group}` group. \
+                 Add `-o <name>` for one of its options \
+                 (see `esp-generate list-options`)."
+            ));
         }
         if args.name.is_none() {
             missing.push_str("\nThe project name is missing. Add the name of your project to the end of the command.");
@@ -331,11 +346,11 @@ fn setup_args_interactive(args: &mut Args) -> Result<()> {
         bail!("{missing}");
     }
 
-    // The chip is not prompted for up front: the TUI exposes it as a
-    // first-class selection group ("chip" category), so users can pick — and
-    // switch — the target chip interactively. When no chip is passed on the
-    // command line we just seed the TUI with a reasonable default; the user
-    // can change it from the first menu level.
+    // Required groups are not prompted for up front: the TUI exposes each
+    // of them as a first-class selection group, and blocks the Save action
+    // until every required group has a pick. When no value is passed on
+    // the command line we just seed the TUI with a reasonable default
+    // tree; the user picks from the first menu level.
 
     if args.name.is_none() {
         let project_name = Text::new("Enter project name:")
@@ -365,19 +380,23 @@ fn main() -> Result<()> {
         check_for_update(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
     }
 
-    // Run the interactive TUI only if chip or name is missing. Both checks
-    // happen against the `-o` list (chip is just another option now) plus
-    // `args.name` — headless mode is rejected inside `setup_args_interactive`
-    // if either piece is still missing.
-    if chip_from_options(&args.option).is_none() || args.name.is_none() {
+    // Run the interactive TUI only if some required group is unpicked or
+    // the name is missing. Required-group membership is driven by the
+    // template's `required` list (see `Template::missing_required_groups`);
+    // headless mode is rejected inside `setup_args_interactive` if either
+    // piece is still missing.
+    let missing_required = TEMPLATE.missing_required_groups(&args.option);
+    if !missing_required.is_empty() || args.name.is_none() {
         setup_args_interactive(&mut args)?;
     }
 
     // In TUI mode the chip is a normal selection group — if the user didn't
-    // pass one via `-o`, just seed the session with the first chip variant
-    // and let them switch from the TUI. Headless mode has already been
-    // rejected above if the user didn't provide a chip, so the `unwrap_or`
-    // branch only runs in the TUI path.
+    // pass one via `-o`, just seed the session tree with the first chip
+    // variant (so there *is* a tree to render) and let them pick from the
+    // TUI. Headless mode has already been rejected above if any required
+    // group was unpicked, so the `unwrap_or` fallback only runs in the TUI
+    // path. The fallback chip is *not* added to `initial_selected`: the
+    // user must actively pick one before Save is unblocked.
     let mut chip = chip_from_options(&args.option).unwrap_or_else(|| {
         Chip::iter()
             .next()
@@ -453,21 +472,19 @@ fn main() -> Result<()> {
     process_options(
         &Template {
             options: initial_options.clone(),
+            required: TEMPLATE.required.clone(),
         },
         &args,
         chip,
     )?;
 
-    // Initial selection for TUI/headless, including toolchain if provided.
-    // Users passing a chip via `-o` already have it in `args.option`; only
-    // append the (defaulted) chip when it isn't already present, so the
-    // `chip` selection group starts with the right entry ticked without
-    // creating a duplicate selected index.
+    // Initial selection for TUI/headless. Whatever the user passed via
+    // `-o` goes in verbatim — in particular, if they didn't pass a chip
+    // the chip selection group starts empty and the TUI blocks Save until
+    // they pick one (see `App::can_save`). In headless mode we already
+    // bailed above if any required group was unsatisfied, so we know the
+    // chip (and any other required group) is already present here.
     let mut initial_selected = args.option.clone();
-    let chip_name = chip.to_string();
-    if !initial_selected.iter().any(|o| o == &chip_name) {
-        initial_selected.push(chip_name);
-    }
     if let Some(ref tc) = args.toolchain {
         initial_selected.push(tc.clone());
     }
@@ -478,7 +495,7 @@ fn main() -> Result<()> {
     let repository = tui::Repository::new(chip, initial_options, &initial_selected);
 
     let (mut selected, flat_options) = if !args.headless {
-        let mut app = tui::App::new(repository);
+        let mut app = tui::App::new(repository, TEMPLATE.required.clone());
 
         let mut terminal = tui::init_terminal()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,10 +114,7 @@ enum SubCommands {
 
 impl SubCommands {
     fn handle(&self) -> Result<()> {
-        fn compatibility_info_text(
-            options: &[&GeneratorOption],
-            opt: &GeneratorOption,
-        ) -> String {
+        fn compatibility_info_text(options: &[&GeneratorOption], opt: &GeneratorOption) -> String {
             // Collect every `compatible` group key used by any variant sharing
             // this option's name (there can be more than one variant — see the
             // duplicate `probe-rs` entries in the template). Order is stable:
@@ -693,8 +690,6 @@ fn main() -> Result<()> {
         let (_, option) = find_option(&selected[idx], &flat_options, chip).unwrap();
         selected.push(option.selection_group.clone());
     }
-
-    selected.push(chip.to_string());
 
     selected.push(if chip.metadata().is_xtensa() {
         "xtensa".to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,10 +419,6 @@ fn main() -> Result<()> {
         setup_args_interactive(&mut args)?;
     }
 
-    // `None` until the user picks one in the TUI; headless mode has
-    // already rejected a missing required `chip` selection above.
-    let mut chip: Option<Chip> = chip_from_options(&args.option);
-
     let name = args.name.clone().unwrap();
 
     let path = &args
@@ -498,9 +494,17 @@ fn main() -> Result<()> {
         keys
     };
 
-    let initial_selections: HashMap<String, String> = chip
-        .map(|c| HashMap::from([("chip".to_string(), c.to_string())]))
-        .unwrap_or_default();
+    // `None` until the user picks one in the TUI; headless mode has
+    // already rejected a missing required `chip` selection above.
+    let mut chip: Option<Chip> = chip_from_options(&args.option);
+
+    // Initial pruning
+    let initial_selections: HashMap<String, String> = TEMPLATE
+        .all_options()
+        .iter()
+        .filter(|o| args.option.iter().any(|n| n == &o.name) && !o.selection_group.is_empty())
+        .map(|o| (o.selection_group.clone(), o.name.clone()))
+        .collect();
     let initial_options = build_options(
         &initial_selections,
         toolchain_category.as_ref(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,59 +114,92 @@ enum SubCommands {
 
 impl SubCommands {
     fn handle(&self) -> Result<()> {
-        fn chip_info_text(options: &[&GeneratorOption], opt: &GeneratorOption) -> String {
-            // Merge the `compatible: { chip: [...] }` allow-lists from every
-            // variant sharing this name (there can be more than one — see the
-            // two `probe-rs` entries in the template). An option that omits
-            // the `chip` entry entirely is considered chip-agnostic, which we
-            // represent by "all chips allowed" so that the final union is a
-            // no-op.
-            let mut chips: Vec<Chip> = Vec::new();
-            let mut all_chip_agnostic = true;
-            for option in options.iter().filter(|o| o.name == opt.name) {
-                match option.compatible.get("chip") {
-                    None => {
-                        all_chip_agnostic = true;
-                        chips.clear();
-                        chips.extend(Chip::iter());
-                        break;
-                    }
-                    Some(names) => {
-                        all_chip_agnostic = false;
-                        for name in names {
-                            if let Ok(chip) = name.parse::<Chip>()
-                                && !chips.contains(&chip)
-                            {
-                                chips.push(chip);
-                            }
-                        }
+        fn compatibility_info_text(
+            options: &[&GeneratorOption],
+            opt: &GeneratorOption,
+        ) -> String {
+            // Collect every `compatible` group key used by any variant sharing
+            // this option's name (there can be more than one variant — see the
+            // duplicate `probe-rs` entries in the template). Order is stable:
+            // first appearance wins, so the rendered sentences line up with
+            // the YAML.
+            let variants: Vec<&GeneratorOption> = options
+                .iter()
+                .copied()
+                .filter(|o| o.name == opt.name)
+                .collect();
+
+            let mut groups: Vec<&str> = Vec::new();
+            for v in &variants {
+                for key in v.compatible.keys() {
+                    if !groups.contains(&key.as_str()) {
+                        groups.push(key.as_str());
                     }
                 }
             }
 
-            let chip_count = Chip::iter().count();
+            let mut sentences: Vec<String> = Vec::new();
+            for group in groups {
+                // Union the allow-list across variants. If any variant doesn't
+                // constrain this group, the name is effectively unconstrained
+                // for that group — mirrors the "first matching variant wins"
+                // semantics `find_option` uses at runtime — so we emit no
+                // sentence for it.
+                let mut allowed: Vec<String> = Vec::new();
+                let mut unconstrained = false;
+                for v in &variants {
+                    match v.compatible.get(group) {
+                        None => {
+                            unconstrained = true;
+                            break;
+                        }
+                        Some(names) => {
+                            for n in names {
+                                if !allowed.contains(n) {
+                                    allowed.push(n.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+                if unconstrained {
+                    continue;
+                }
 
-            if all_chip_agnostic || chips.len() == chip_count {
-                String::new()
-            } else if chips.len() < chip_count / 2 {
-                format!(
-                    "Only available on {}.",
-                    chips
+                // Enumerate the full membership of the selection group from
+                // the template itself, deduplicated by option name. This is
+                // the generalisation of the old `Chip::iter().count()` — any
+                // group whose options are authored in YAML (chip, module,
+                // log-frontend, …) supplies its own denominator.
+                let mut total: Vec<&str> = Vec::new();
+                for o in options.iter().filter(|o| o.selection_group == group) {
+                    if !total.contains(&o.name.as_str()) {
+                        total.push(o.name.as_str());
+                    }
+                }
+
+                // Nothing useful to say when the option is compatible with
+                // every member of the group (or the group is empty — which
+                // only happens for malformed templates, but we degrade
+                // silently rather than emit a confusing sentence).
+                if total.is_empty() || allowed.len() >= total.len() {
+                    continue;
+                }
+
+                let sentence = if allowed.len() < total.len() / 2 {
+                    format!("Compatible with {group}: {}.", allowed.join(", "))
+                } else {
+                    let excluded: Vec<&str> = total
                         .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            } else {
-                format!(
-                    "Not available on {}.",
-                    Chip::iter()
-                        .filter(|c| !chips.contains(c))
-                        .map(|c| c.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
+                        .copied()
+                        .filter(|n| !allowed.iter().any(|a| a == n))
+                        .collect();
+                    format!("Not compatible with {group}: {}.", excluded.join(", "))
+                };
+                sentences.push(sentence);
             }
+
+            sentences.join(" ")
         }
 
         let all_options = TEMPLATE.all_options();
@@ -210,10 +243,10 @@ impl SubCommands {
                             help_text.push_str(&readable.collect::<Vec<String>>().join(", "));
                             help_text.push('.');
                         }
-                        let chip_info = chip_info_text(&all_options, option);
-                        if !chip_info.is_empty() {
+                        let compat_info = compatibility_info_text(&all_options, option);
+                        if !compat_info.is_empty() {
                             help_text.push(' ');
-                            help_text.push_str(&chip_info);
+                            help_text.push_str(&compat_info);
                         }
                         println!("    {}: {help_text}", option.name);
                     }
@@ -251,9 +284,9 @@ impl SubCommands {
                             }
                         }
                     }
-                    let chip_info = chip_info_text(&all_options, option);
-                    if !chip_info.is_empty() {
-                        println!("{}", chip_info);
+                    let compat_info = compatibility_info_text(&all_options, option);
+                    if !compat_info.is_empty() {
+                        println!("{}", compat_info);
                     }
                 } else {
                     println!("Unknown option: {}", option);

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,7 +522,7 @@ fn main() -> Result<()> {
     // Single source of truth: `Repository` owns the options tree from here on.
     // The CLI post-processing code below reads `flat_options` / `options` back
     // out of it regardless of which branch (TUI or headless) populated them.
-    let repository = tui::Repository::new(chip, initial_options, &initial_selected);
+    let repository = tui::Repository::new(initial_options, &initial_selected);
 
     let (mut selected, flat_options) = if !args.headless {
         let mut app = tui::App::new(repository, TEMPLATE.required.clone());
@@ -589,7 +589,7 @@ fn main() -> Result<()> {
                 let desired_chip = current_compat
                     .get("chip")
                     .and_then(|name| name.parse().ok())
-                    .unwrap_or(app.repository.config.chip);
+                    .unwrap_or(chip);
 
                 let filtered = toolchain::toolchains_for_chip(
                     &cached_toolchains,
@@ -606,7 +606,8 @@ fn main() -> Result<()> {
                     toolchain_category.as_ref(),
                     &filtered.names,
                 );
-                app.set_options(desired_chip, new_options);
+                app.set_options(new_options);
+                chip = desired_chip;
                 populated_compat = Some(app.repository.config.compatibility_signature());
                 populated_with_scan = scan_finished;
             }
@@ -640,8 +641,9 @@ fn main() -> Result<()> {
         // Pick up whatever chip the TUI ended on. The user may have switched
         // chips mid-session; everything downstream (linker config, template
         // variables, validation) must match the chip the options were built
-        // against.
-        chip = app.repository.config.chip;
+        // against. `can_save` gates on the `chip` required group, so
+        // `selected_chip()` is guaranteed to be `Some` here.
+        chip = app.repository.selected_chip().unwrap_or(chip);
 
         (sel, app.repository.config.flat_options)
     } else {
@@ -672,7 +674,7 @@ fn main() -> Result<()> {
     // category in `flat_options` (TUI via scan results, headless via the
     // `--toolchain` CLI hint), so `find_option` resolves in either case.
     let selected_toolchain = selected.iter().find_map(|name| {
-        let (_, opt) = find_option(name, &flat_options, chip)?;
+        let (_, opt) = find_option(name, &flat_options)?;
         if opt.selection_group == "toolchain" {
             Some(name.clone())
         } else {
@@ -681,7 +683,7 @@ fn main() -> Result<()> {
     });
 
     let selected_module = selected.iter().find_map(|name| {
-        let (_, opt) = find_option(name, &flat_options, chip)?;
+        let (_, opt) = find_option(name, &flat_options)?;
         if opt.selection_group == "module" {
             Some(name.clone())
         } else {
@@ -689,9 +691,8 @@ fn main() -> Result<()> {
         }
     });
 
-    // Also add the active selection groups
     for idx in 0..selected.len() {
-        let (_, option) = find_option(&selected[idx], &flat_options, chip).unwrap();
+        let (_, option) = find_option(&selected[idx], &flat_options).unwrap();
         selected.push(option.selection_group.clone());
     }
 
@@ -731,7 +732,7 @@ fn main() -> Result<()> {
     // do with them (see the pin-reservation block below), so they're
     // deliberately skipped here instead of being joined into a string.
     for name in &selected {
-        let Some((_, opt)) = find_option(name, &flat_options, chip) else {
+        let Some((_, opt)) = find_option(name, &flat_options) else {
             continue;
         };
         for (key, value) in &opt.sets {
@@ -753,7 +754,7 @@ fn main() -> Result<()> {
     let mut reserved_gpio_code = String::new();
 
     if let Some(ref module_name) = selected_module {
-        if let Some((_, module_option)) = find_option(module_name, &flat_options, chip) {
+        if let Some((_, module_option)) = find_option(module_name, &flat_options) {
             // The module option carries its limitation tags as a list-valued
             // `sets` entry; a missing entry means "no pins to reserve", not
             // an error — e.g. a chip-specific module with nothing special
@@ -1177,7 +1178,6 @@ fn process_options(template: &Template, args: &Args, chip: Chip) -> Result<()> {
     }
 
     let selected_config = ActiveConfiguration {
-        chip,
         selected,
         flat_options,
         options: template.options.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -538,56 +538,59 @@ fn main() -> Result<()> {
         // cache as "no toolchains available" — the toolchain category then
         // keeps its "Scanning installed toolchains…" placeholder.
         let mut cached_toolchains: Vec<toolchain::ToolchainInfo> = Vec::new();
-        // The chip that `app.repository.options` was last built for. `None`
-        // forces the first-ever rebuild regardless of whether the chip has
-        // actually changed — this is how we swap the placeholder toolchain
-        // category out for real entries once the scan completes.
-        let mut populated_for_chip: Option<Chip> = None;
+        // Tracks whether `cached_toolchains` reflects a *completed* scan.
+        let mut scan_finished = toolchain_scan.is_none();
+        // Compatibility-group selections the tree was last built for.
+        let mut populated_compat: Option<HashMap<String, String>> = None;
+        // Whether the last rebuild ran with a completed scan. Flips the
+        // trigger when the scan finishes so the placeholder gets swapped.
+        let mut populated_with_scan = scan_finished;
 
         while running {
             // Toolchain scan in the background. Chip-agnostic on purpose: the
             // cached list is reused across chip switches, and per-chip filtering
             // happens down below in the rebuild block.
             if let Some(scan) = toolchain_scan.as_mut() {
-                let finished = match scan.try_get_toolchain_list() {
-                    None => false,
+                match scan.try_get_toolchain_list() {
+                    None => {
+                        app.set_toolchains_loading(true);
+                    }
                     Some(Ok(list)) => {
-                        cached_toolchains = list.clone();
-                        true
+                        if !scan_finished {
+                            cached_toolchains = list.clone();
+                            scan_finished = true;
+                        }
+                        app.set_toolchains_loading(false);
                     }
                     Some(Err(err)) => {
-                        log::warn!("Toolchain scan failed: {err}");
-                        true
+                        if !scan_finished {
+                            log::warn!("Toolchain scan failed: {err}");
+                            scan_finished = true;
+                        }
+                        app.set_toolchains_loading(false);
                     }
-                };
-
-                app.set_toolchains_loading(!finished);
-                if finished {
-                    // Clear state to rebuild UI with correct toolchain data.
-                    populated_for_chip = None;
-                    // Stop re-checking, scan is a one-shot process.
-                    toolchain_scan = None;
                 }
             }
 
             // Rebuild-on-demand:
-            //   * `selected_chip` diverges from the tree's chip → user picked
-            //     a different chip in the `chip` category; rebuild the whole
-            //     tree for that chip and collapse the menu to the root so the
-            //     user isn't stranded inside a now-irrelevant category.
+            //   * the `compatible` signature changed → some compat-relevant
+            //     option (chip, log-frontend, …) was toggled; rebuild so the
+            //     tree reflects the new constraints.
             //   * scan just finished or we haven't populated yet → rebuild to
             //     swap the toolchain placeholder for real entries.
             // Both paths flow through the same `build_options_for_chip` +
-            // `App::set_options` pair, keeping chip selection and toolchain
-            // repopulation on one code path.
+            // `App::set_options` pair, keeping compat-driven rebuilds and
+            // toolchain refresh on one code path.
+            let current_compat = app.repository.config.compatibility_signature();
+            let signature_changed = populated_compat.as_ref() != Some(&current_compat);
+            let scan_needs_reflecting = scan_finished && !populated_with_scan;
 
-            let scan_finished = toolchain_scan.is_none();
-            let tree_chip = app.repository.config.chip;
-            let desired_chip = app.repository.selected_chip().unwrap_or(tree_chip);
-            let chip_changed = desired_chip != tree_chip;
-            let needs_initial_populate = scan_finished && populated_for_chip != Some(desired_chip);
+            if signature_changed || scan_needs_reflecting {
+                let desired_chip = current_compat
+                    .get("chip")
+                    .and_then(|name| name.parse().ok())
+                    .unwrap_or(app.repository.config.chip);
 
-            if chip_changed || needs_initial_populate {
                 let filtered = toolchain::toolchains_for_chip(
                     &cached_toolchains,
                     desired_chip,
@@ -603,8 +606,9 @@ fn main() -> Result<()> {
                     toolchain_category.as_ref(),
                     &filtered.names,
                 );
-                app.set_options(desired_chip, new_options, chip_changed);
-                populated_for_chip = Some(desired_chip);
+                app.set_options(desired_chip, new_options);
+                populated_compat = Some(app.repository.config.compatibility_signature());
+                populated_with_scan = scan_finished;
             }
 
             // draw a frame

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,6 @@ use std::{
     sync::LazyLock,
     time::Duration,
 };
-use strum::IntoEnumIterator;
 use taplo::formatter::Options;
 
 use esp_generate::template_files::TEMPLATE_FILES;
@@ -420,18 +419,9 @@ fn main() -> Result<()> {
         setup_args_interactive(&mut args)?;
     }
 
-    // In TUI mode the chip is a normal selection group — if the user didn't
-    // pass one via `-o`, just seed the session tree with the first chip
-    // variant (so there *is* a tree to render) and let them pick from the
-    // TUI. Headless mode has already been rejected above if any required
-    // group was unpicked, so the `unwrap_or` fallback only runs in the TUI
-    // path. The fallback chip is *not* added to `initial_selected`: the
-    // user must actively pick one before Save is unblocked.
-    let mut chip = chip_from_options(&args.option).unwrap_or_else(|| {
-        Chip::iter()
-            .next()
-            .expect("at least one chip variant must exist")
-    });
+    // `None` until the user picks one in the TUI; headless mode has
+    // already rejected a missing required `chip` selection above.
+    let mut chip: Option<Chip> = chip_from_options(&args.option);
 
     let name = args.name.clone().unwrap();
 
@@ -493,12 +483,30 @@ fn main() -> Result<()> {
         (true, Some(tc)) => std::slice::from_ref(tc),
         _ => &[],
     };
-    let initial_options =
-        build_options_for_chip(chip, toolchain_category.as_ref(), headless_toolchain);
+    // Compat groups referenced anywhere in the pristine template — the set
+    // of selections the TUI loop watches to trigger rebuilds.
+    let compat_groups: Vec<String> = {
+        let mut seen = HashSet::new();
+        let mut keys = Vec::new();
+        for opt in TEMPLATE.all_options() {
+            for key in opt.compatible.keys() {
+                if seen.insert(key) {
+                    keys.push(key.clone());
+                }
+            }
+        }
+        keys
+    };
 
-    // `process_options` validates `--option` against the options tree. We keep
-    // a transient `Template` around for just this call; the authoritative copy
-    // of the tree moves into `Repository` right after.
+    let initial_selections: HashMap<String, String> = chip
+        .map(|c| HashMap::from([("chip".to_string(), c.to_string())]))
+        .unwrap_or_default();
+    let initial_options = build_options(
+        &initial_selections,
+        toolchain_category.as_ref(),
+        headless_toolchain,
+    );
+
     process_options(
         &Template {
             options: initial_options.clone(),
@@ -508,20 +516,11 @@ fn main() -> Result<()> {
         chip,
     )?;
 
-    // Initial selection for TUI/headless. Whatever the user passed via
-    // `-o` goes in verbatim — in particular, if they didn't pass a chip
-    // the chip selection group starts empty and the TUI blocks Save until
-    // they pick one (see `App::can_save`). In headless mode we already
-    // bailed above if any required group was unsatisfied, so we know the
-    // chip (and any other required group) is already present here.
     let mut initial_selected = args.option.clone();
     if let Some(ref tc) = args.toolchain {
         initial_selected.push(tc.clone());
     }
 
-    // Single source of truth: `Repository` owns the options tree from here on.
-    // The CLI post-processing code below reads `flat_options` / `options` back
-    // out of it regardless of which branch (TUI or headless) populated them.
     let repository = tui::Repository::new(initial_options, &initial_selected);
 
     let (mut selected, flat_options) = if !args.headless {
@@ -532,24 +531,12 @@ fn main() -> Result<()> {
         let mut final_selected: Option<Vec<String>> = None;
         let mut running = true;
 
-        // Latest successful toolchain scan, cached so that per-chip filtering
-        // (and any subsequent chip switches) can rerun without re-scanning.
-        // Starts empty; the options-tree rebuild loop below treats an empty
-        // cache as "no toolchains available" — the toolchain category then
-        // keeps its "Scanning installed toolchains…" placeholder.
         let mut cached_toolchains: Vec<toolchain::ToolchainInfo> = Vec::new();
-        // Tracks whether `cached_toolchains` reflects a *completed* scan.
         let mut scan_finished = toolchain_scan.is_none();
-        // Compatibility-group selections the tree was last built for.
         let mut populated_compat: Option<HashMap<String, String>> = None;
-        // Whether the last rebuild ran with a completed scan. Flips the
-        // trigger when the scan finishes so the placeholder gets swapped.
         let mut populated_with_scan = scan_finished;
 
         while running {
-            // Toolchain scan in the background. Chip-agnostic on purpose: the
-            // cached list is reused across chip switches, and per-chip filtering
-            // happens down below in the rebuild block.
             if let Some(scan) = toolchain_scan.as_mut() {
                 match scan.try_get_toolchain_list() {
                     None => {
@@ -581,19 +568,19 @@ fn main() -> Result<()> {
             // Both paths flow through the same `build_options_for_chip` +
             // `App::set_options` pair, keeping compat-driven rebuilds and
             // toolchain refresh on one code path.
-            let current_compat = app.repository.config.compatibility_signature();
+            let current_compat = app
+                .repository
+                .config
+                .compatibility_signature(&compat_groups);
             let signature_changed = populated_compat.as_ref() != Some(&current_compat);
             let scan_needs_reflecting = scan_finished && !populated_with_scan;
 
             if signature_changed || scan_needs_reflecting {
-                let desired_chip = current_compat
-                    .get("chip")
-                    .and_then(|name| name.parse().ok())
-                    .unwrap_or(chip);
-
                 let filtered = toolchain::toolchains_for_chip(
                     &cached_toolchains,
-                    desired_chip,
+                    current_compat
+                        .get("chip")
+                        .and_then(|name| name.parse().ok()),
                     &msrv,
                     args.toolchain.as_deref(),
                 );
@@ -601,14 +588,17 @@ fn main() -> Result<()> {
                     log::warn!("{warning}");
                 }
 
-                let new_options = build_options_for_chip(
-                    desired_chip,
+                let new_options = build_options(
+                    &current_compat,
                     toolchain_category.as_ref(),
                     &filtered.names,
                 );
                 app.set_options(new_options);
-                chip = desired_chip;
-                populated_compat = Some(app.repository.config.compatibility_signature());
+                populated_compat = Some(
+                    app.repository
+                        .config
+                        .compatibility_signature(&compat_groups),
+                );
                 populated_with_scan = scan_finished;
             }
 
@@ -638,17 +628,16 @@ fn main() -> Result<()> {
             return Ok(());
         };
 
-        // Pick up whatever chip the TUI ended on. The user may have switched
-        // chips mid-session; everything downstream (linker config, template
-        // variables, validation) must match the chip the options were built
-        // against. `can_save` gates on the `chip` required group, so
-        // `selected_chip()` is guaranteed to be `Some` here.
-        chip = app.repository.selected_chip().unwrap_or(chip);
+        chip = app.repository.selected_chip();
 
         (sel, app.repository.config.flat_options)
     } else {
         (initial_selected, repository.config.flat_options)
     };
+
+    // FIXME: do not assume the template even has a "chip" property
+    let chip = chip.expect("chip must be set by the time the TUI exits / headless validates");
+
     let mut toolchain_replaced = false;
 
     let selected_options = selected
@@ -870,40 +859,33 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Prune every option whose `compatible: { chip: [...] }` allow-list excludes
-/// the given chip. Options that don't constrain `chip` (or that don't have a
-/// `compatible` entry at all) are kept. Empty categories are dropped.
-///
-/// This is the generalised replacement for the old `remove_incompatible_chip_options`
-/// pass: compatibility is evaluated from the `compatible` map on
-/// [`GeneratorOption`] against the chip the TUI currently has selected in the
-/// `chip` selection group, instead of the retired `chips: Vec<Chip>` field.
-///
-/// Only the `chip` group is evaluated here because it's the only group whose
-/// selection is already known at tree-build time. Any other `compatible`
-/// constraints are evaluated at runtime by
-/// [`crate::config::ActiveConfiguration::is_option_compatible`] and are
-/// enforced via the cascade in [`drop_unsatisfied`].
-fn prune_chip_incompatible_options(chip: Chip, options: &mut Vec<GeneratorOptionItem>) {
-    let chip_name = chip.to_string();
+/// Prune options whose `compatible` constraints aren't satisfied by
+/// `selections`. A `compatible` group with no (or empty) pick in
+/// `selections` also prunes the option. Categories that end up empty are
+/// dropped.
+fn prune_incompatible_options(
+    selections: &HashMap<String, String>,
+    options: &mut Vec<GeneratorOptionItem>,
+) {
     options.retain_mut(|opt| match opt {
         GeneratorOptionItem::Category(category) => {
-            prune_chip_incompatible_options(chip, &mut category.options);
+            prune_incompatible_options(selections, &mut category.options);
             !category.options.is_empty()
         }
-        GeneratorOptionItem::Option(option) => match option.compatible.get("chip") {
-            None => true,
-            Some(allowed) => allowed.iter().any(|n| n == &chip_name),
-        },
+        GeneratorOptionItem::Option(option) => option.compatible.iter().all(|(group, allowed)| {
+            match selections.get(group).filter(|s| !s.is_empty()) {
+                Some(picked) => allowed.iter().any(|n| n == picked),
+                None => false,
+            }
+        }),
     });
 }
 
-/// Build a fully-prepared options tree for the given chip off the pristine
-/// [`TEMPLATE`].
+/// Build a fully-prepared options tree off the pristine [`TEMPLATE`].
 ///
 /// Applies, in order:
-///   1. chip-compat pruning (`prune_chip_incompatible_options`), which
-///      also hides modules whose `compatible.chip` excludes this chip,
+///   1. compat pruning against `selections` (see
+///      [`prune_incompatible_options`]),
 ///   2. toolchain-category population (`ToolchainCategory::populate`), if a
 ///      `ToolchainCategory` was captured off the original template.
 ///
@@ -911,17 +893,17 @@ fn prune_chip_incompatible_options(chip: Chip, options: &mut Vec<GeneratorOption
 /// `template.yaml` and validated once at [`TEMPLATE`] load; no runtime
 /// population is needed for either.
 ///
-/// This is the single place that knows how to turn "chip + current toolchain
-/// list" into a ready-to-use options tree, and it is deliberately cheap enough
-/// to re-run on every chip switch or scan result (no subprocesses; the
-/// toolchain info is already cached in-memory by the caller).
-fn build_options_for_chip(
-    chip: Chip,
+/// `selections` typically carries at least `{ "chip" => <chip name> }` — any
+/// other `(group, pick)` entries enable additional build-time pruning (e.g.
+/// dropping options incompatible with the current `log-frontend`). Groups
+/// absent from `selections` are left to the runtime compatibility check.
+fn build_options(
+    selections: &HashMap<String, String>,
     toolchain_category: Option<&toolchain::ToolchainCategory>,
     toolchains: &[String],
 ) -> Vec<GeneratorOptionItem> {
     let mut options = TEMPLATE.options.clone();
-    prune_chip_incompatible_options(chip, &mut options);
+    prune_incompatible_options(selections, &mut options);
     if let Some(category) = toolchain_category {
         category.populate(&mut options, toolchains);
     }
@@ -1137,10 +1119,10 @@ fn process_file(
     Some(res)
 }
 
-fn process_options(template: &Template, args: &Args, chip: Chip) -> Result<()> {
+fn process_options(template: &Template, args: &Args, chip: Option<Chip>) -> Result<()> {
     let mut success = true;
     // Two option catalogues, with complementary coverage:
-    //   - `populated_options` is the chip-pruned, post-`build_options_for_chip`
+    //   - `populated_options` is the pruned, post-`build_options`
     //     view: it DOES know about dynamically-populated entries (each
     //     supported chip in the `chip` category, each module for the current
     //     chip in the `module` category), but it has already been filtered
@@ -1156,22 +1138,19 @@ fn process_options(template: &Template, args: &Args, chip: Chip) -> Result<()> {
     let populated_options = template.all_options();
     let pristine_options = TEMPLATE.all_options();
 
-    // Seed the simulated selection with the CLI `-o` list. The chip entry —
-    // now just another `-o` option — is already in `args.option` if the user
-    // asked for it; if they didn't (TUI default path), add it synthetically
-    // so that option-level `compatible: { chip: [...] }` constraints are
-    // satisfied during validation. Without it, every chip-restricted option
-    // would fail `is_option_compatible` and look "invalid" to the validator.
-    let chip_name = chip.to_string();
+    // Seed simulated selection with CLI `-o` plus the chip pick (when set)
+    // so `compatible: { chip: [...] }` constraints can be validated.
+    let chip_name = chip.map(|c| c.to_string());
     let flat_options = flatten_options(&template.options);
     let mut selected: Vec<usize> = args
         .option
         .iter()
         .flat_map(|opt_name| flat_options.iter().position(|o| &o.name == opt_name))
         .collect();
-    if let Some(pos) = flat_options
-        .iter()
-        .position(|o| o.selection_group == "chip" && o.name == chip_name)
+    if let Some(ref name) = chip_name
+        && let Some(pos) = flat_options
+            .iter()
+            .position(|o| o.selection_group == "chip" && &o.name == name)
         && !selected.contains(&pos)
     {
         selected.push(pos);
@@ -1259,8 +1238,9 @@ fn process_options(template: &Template, args: &Args, chip: Chip) -> Result<()> {
                 option_found = true;
 
                 if let Some(allowed) = option_item.compatible.get("chip") {
-                    if !allowed.iter().any(|n| n == &chip_name) {
-                        continue;
+                    match chip_name.as_deref() {
+                        Some(name) if allowed.iter().any(|n| n == name) => {}
+                        _ => continue,
                     }
                 }
                 option_found_for_chip = true;
@@ -1271,7 +1251,16 @@ fn process_options(template: &Template, args: &Args, chip: Chip) -> Result<()> {
             log::error!("Unknown option '{option}'");
             success = false;
         } else if !option_found_for_chip {
-            log::error!("Option '{option}' is not supported for chip {chip}");
+            match chip {
+                Some(c) => {
+                    log::error!("Option '{option}' is not supported for chip {c}");
+                }
+                None => {
+                    log::error!(
+                        "Option '{option}' has a chip-compatibility constraint but no chip was selected"
+                    );
+                }
+            }
             success = false;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,9 @@ static TEMPLATE: LazyLock<Template> = LazyLock::new(|| {
     // `Chip` enum for the generator to work.
     chip_selector::validate_chip_category(&template.options)
         .expect("invalid `chip` category in bundled template");
+    template
+        .validate_required()
+        .expect("invalid `required` list in bundled template");
 
     template
 });
@@ -862,10 +865,11 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Prune options whose `compatible` constraints aren't satisfied by
-/// `selections`. A `compatible` group with no (or empty) pick in
-/// `selections` also prunes the option. Categories that end up empty are
-/// dropped.
+/// Prune options whose `compatible` constraints are actively violated by
+/// `selections`. A group that is absent from `selections`, or present with an
+/// empty value, is treated as unconstrained — the option is kept and the
+/// runtime compatibility check handles it once the user makes a pick.
+/// Categories that end up empty are dropped.
 fn prune_incompatible_options(
     selections: &HashMap<String, String>,
     options: &mut Vec<GeneratorOptionItem>,
@@ -878,7 +882,7 @@ fn prune_incompatible_options(
         GeneratorOptionItem::Option(option) => option.compatible.iter().all(|(group, allowed)| {
             match selections.get(group).filter(|s| !s.is_empty()) {
                 Some(picked) => allowed.iter().any(|n| n == picked),
-                None => false,
+                None => true,
             }
         }),
     });
@@ -899,7 +903,8 @@ fn prune_incompatible_options(
 /// `selections` typically carries at least `{ "chip" => <chip name> }` — any
 /// other `(group, pick)` entries enable additional build-time pruning (e.g.
 /// dropping options incompatible with the current `log-frontend`). Groups
-/// absent from `selections` are left to the runtime compatibility check.
+/// absent from `selections`, or present with an empty value, are treated as
+/// unconstrained and left to the runtime compatibility check.
 fn build_options(
     selections: &HashMap<String, String>,
     toolchain_category: Option<&toolchain::ToolchainCategory>,

--- a/src/template.rs
+++ b/src/template.rs
@@ -191,14 +191,56 @@ impl GeneratorOptionItem {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Template {
     pub options: Vec<GeneratorOptionItem>,
+    /// Names of selection groups that must have at least one option selected
+    /// before generation can proceed. A missing required group is a hard
+    /// error in headless mode and blocks the Save action in the TUI — the
+    /// TUI also surfaces which groups still need a pick so the user knows
+    /// what's gating the "save and generate" key.
+    #[serde(default)]
+    pub required: Vec<String>,
 }
 
 impl Template {
     pub fn all_options(&self) -> Vec<&GeneratorOption> {
         all_options_in(&self.options)
+    }
+
+    /// Validate that every entry in [`Self::required`] is non-empty and
+    /// names a selection group that actually carries at least one option
+    /// in the template.
+    pub fn validate_required(&self) -> Result<(), String> {
+        let all = self.all_options();
+        for group in &self.required {
+            if group.is_empty() {
+                return Err("required selection group names must be non-empty".into());
+            }
+            let has_member = all.iter().any(|o| o.selection_group == *group);
+            if !has_member {
+                return Err(format!(
+                    "required selection group `{group}` has no options in the template"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Return the required groups that are not satisfied by the given set
+    /// of selected option names.
+    pub fn missing_required_groups(&self, selected_names: &[String]) -> Vec<String> {
+        let all = self.all_options();
+        self.required
+            .iter()
+            .filter(|group| {
+                !selected_names.iter().any(|name| {
+                    all.iter()
+                        .any(|o| &o.selection_group == *group && &o.name == name)
+                })
+            })
+            .cloned()
+            .collect()
     }
 
     /// Parses a bundled [`Template`] from its YAML root document,
@@ -259,24 +301,18 @@ where
             let path = match &tagged.value {
                 Value::String(s) => s.clone(),
                 other => {
-                    return Err(format!(
-                        "!Include expects a string path, got {:?}",
-                        other
-                    ));
+                    return Err(format!("!Include expects a string path, got {:?}", other));
                 }
             };
 
             if stack.iter().any(|p| p == &path) {
                 let mut chain = stack.clone();
                 chain.push(path);
-                return Err(format!(
-                    "template-include cycle: {}",
-                    chain.join(" -> ")
-                ));
+                return Err(format!("template-include cycle: {}", chain.join(" -> ")));
             }
 
-            let contents = loader(&path)
-                .ok_or_else(|| format!("template include `{path}` not found"))?;
+            let contents =
+                loader(&path).ok_or_else(|| format!("template include `{path}` not found"))?;
             let mut inner: Value = serde_yaml::from_str(&contents)
                 .map_err(|e| format!("failed to parse include `{path}`: {e}"))?;
 
@@ -361,6 +397,71 @@ options:
 "#;
         let err = Template::load(main, |_| None).expect_err("should error");
         assert!(err.contains("missing.yaml"), "{err}");
+    }
+
+    #[test]
+    fn validate_required_rejects_unknown_or_empty_groups() {
+        // A `required` entry that doesn't name a real selection group is a
+        // template bug — satisfying it is impossible, so no user-driven
+        // selection could ever unblock generation. Catching it at load
+        // keeps the failure close to its cause.
+        let t = Template {
+            required: vec!["nonexistent".to_string()],
+            ..Template::default()
+        };
+        let err = t
+            .validate_required()
+            .expect_err("unknown group should fail");
+        assert!(err.contains("nonexistent"), "{err}");
+
+        let t = Template {
+            required: vec![String::new()],
+            ..Template::default()
+        };
+        let err = t
+            .validate_required()
+            .expect_err("empty group name should fail");
+        assert!(err.contains("non-empty"), "{err}");
+    }
+
+    #[test]
+    fn missing_required_groups_reports_unsatisfied_groups_only() {
+        // A template that declares `chip` as required. When no chip-like
+        // name is selected, `missing_required_groups` reports `chip`;
+        // once a matching name is selected the group drops out.
+        let main = r#"
+required:
+  - chip
+options:
+  - !Category
+    name: chip
+    display_name: Chip
+    options:
+      - !Option
+        name: esp32
+        display_name: ESP32
+        selection_group: chip
+      - !Option
+        name: esp32c6
+        display_name: ESP32-C6
+        selection_group: chip
+"#;
+        let template = Template::load(main, |_| None).expect("should parse");
+        template.validate_required().expect("chip group exists");
+
+        assert_eq!(
+            template.missing_required_groups(&[]),
+            vec!["chip".to_string()]
+        );
+        assert_eq!(
+            template.missing_required_groups(&["unrelated".to_string()]),
+            vec!["chip".to_string()]
+        );
+        assert!(
+            template
+                .missing_required_groups(&["esp32".to_string()])
+                .is_empty()
+        );
     }
 
     #[test]

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -180,16 +180,27 @@ fn active_rustup_toolchain() -> Option<String> {
 /// exclusion of generic toolchains, and CLI-toolchain sort/validation — so
 /// that the cached scan data stays untouched across chip switches.
 ///
+/// When `chip` is `None` every scanned toolchain is returned unfiltered;
+/// the per-chip gates run again on the next rebuild once a chip is picked.
+///
 /// Previously-fatal CLI-toolchain mismatches are now returned as warnings:
 /// the caller decides whether to promote them (headless) or surface them in
 /// the TUI footer. Dynamic chip switching requires this: a chip switch that
 /// invalidates the CLI toolchain must not be unrecoverable.
 pub fn toolchains_for_chip(
     all: &[ToolchainInfo],
-    chip: Chip,
+    chip: Option<Chip>,
     msrv: &check::Version,
     cli_hint: Option<&str>,
 ) -> FilteredToolchains {
+    let Some(chip) = chip else {
+        let names: Vec<String> = all.iter().map(|tc| tc.name.clone()).collect();
+        return FilteredToolchains {
+            names,
+            warnings: Vec::new(),
+        };
+    };
+
     let target = chip.metadata().target().to_string();
 
     let mut names: Vec<String> = all

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -68,10 +68,8 @@ impl Repository {
     /// keep my state consistent" primitive.
     ///
     /// The menu path is trimmed to the depth that still resolves against the
-    /// new tree rather than reset wholesale, so callers that repopulate a
-    /// single category on the *same* chip (notably the toolchain scan) keep
-    /// their cursor where it is; callers that truly switch chips typically
-    /// want to [`Self::reset_path`] after this.
+    /// new tree, so categories that vanish drop out while surviving ones keep
+    /// the user's cursor in place.
     pub fn set_options(&mut self, chip: Chip, options: Vec<GeneratorOptionItem>) {
         self.config.reset_options(chip, options);
 
@@ -88,12 +86,6 @@ impl Repository {
             }
         }
         self.path.truncate(valid_depth);
-    }
-
-    /// Collapse the menu path back to the root. Intended for callers that have
-    /// just switched chip and want the UI to start from a known location.
-    pub fn reset_path(&mut self) {
-        self.path.clear();
     }
 
     /// Returns the *explicitly* selected toolchain, if there is any
@@ -633,27 +625,15 @@ impl App {
     ///
     /// `Repository::set_options` trims the navigation path to whatever still
     /// resolves in the new tree; we mirror that here on the `ListState` stack.
-    /// When the caller asks for a path reset (the typical chip-switch case),
-    /// we also collapse back to the root menu with a fresh selection at the
-    /// top so the user isn't dropped inside a now-unrelated category.
-    pub fn set_options(&mut self, chip: Chip, options: Vec<GeneratorOptionItem>, reset_path: bool) {
+    pub fn set_options(&mut self, chip: Chip, options: Vec<GeneratorOptionItem>) {
         self.repository.set_options(chip, options);
-        if reset_path {
-            self.repository.reset_path();
-        }
 
-        // The state stack is always `path_len + 1` — one for the root level,
-        // one per entered category. Truncate mirrors the path trim; the min-1
-        // floor guarantees we always have a state for the visible level.
         let desired = self.repository.path_len() + 1;
         self.state.truncate(desired.max(1));
         if self.state.is_empty() {
             let mut fresh = ListState::default();
             fresh.select(Some(0));
             self.state.push(fresh);
-        }
-        if reset_path && let Some(last) = self.state.last_mut() {
-            last.select(Some(0));
         }
     }
     pub fn selected_options(&self) -> Vec<String> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1208,7 +1208,7 @@ mod test {
             ],
         );
 
-        // Rebuild for the new chip as if `build_options_for_chip(Esp32c6, …)`
+        // Rebuild for the new chip as if `build_options({chip: "esp32c6"}, …)`
         // had been called: `only-on-esp32` is gone, the chip group still
         // carries both entries (it's chip-agnostic), and the user has now
         // ticked `esp32c6`.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -189,9 +189,10 @@ impl Repository {
     fn is_item_visible(&self, item: &GeneratorOptionItem) -> bool {
         match item {
             GeneratorOptionItem::Option(option) => self.config.is_option_compatible(option),
-            GeneratorOptionItem::Category(category) => {
-                category.options.iter().any(|child| self.is_item_visible(child))
-            }
+            GeneratorOptionItem::Category(category) => category
+                .options
+                .iter()
+                .any(|child| self.is_item_visible(child)),
         }
     }
 
@@ -552,10 +553,14 @@ pub struct App {
     ui_elements: UiElements,
     colors: Colors,
     toolchains_loading: bool,
+    /// Selection groups that must have an option picked before
+    /// `s`/`S` actually triggers generation. Sourced from
+    /// [`esp_generate::template::Template::required`].
+    required_groups: Vec<String>,
 }
 
 impl App {
-    pub fn new(repository: Repository) -> Self {
+    pub fn new(repository: Repository, required_groups: Vec<String>) -> Self {
         let mut initial_state = ListState::default();
         initial_state.select(Some(0));
 
@@ -572,7 +577,25 @@ impl App {
             ui_elements,
             colors,
             toolchains_loading: false,
+            required_groups,
         }
+    }
+
+    /// Required selection groups that currently have no option selected in
+    /// the live tree. Empty iff every required group has a pick — the
+    /// gate [`Self::can_save`] uses to allow `s`/`S` to trigger generation.
+    pub fn missing_required_groups(&self) -> Vec<String> {
+        self.repository
+            .config
+            .missing_required_groups(&self.required_groups)
+    }
+
+    /// True when every required selection group has at least one option
+    /// selected. The `s`/`S` key is a no-op while this returns `false`;
+    /// the footer surfaces which groups are still missing so the user
+    /// knows why Save is gated.
+    pub fn can_save(&self) -> bool {
+        self.missing_required_groups().is_empty()
     }
     pub fn selected(&self) -> usize {
         if let Some(current) = self.state.last() {
@@ -613,12 +636,7 @@ impl App {
     /// When the caller asks for a path reset (the typical chip-switch case),
     /// we also collapse back to the root menu with a fresh selection at the
     /// top so the user isn't dropped inside a now-unrelated category.
-    pub fn set_options(
-        &mut self,
-        chip: Chip,
-        options: Vec<GeneratorOptionItem>,
-        reset_path: bool,
-    ) {
+    pub fn set_options(&mut self, chip: Chip, options: Vec<GeneratorOptionItem>, reset_path: bool) {
         self.repository.set_options(chip, options);
         if reset_path {
             self.repository.reset_path();
@@ -634,9 +652,7 @@ impl App {
             fresh.select(Some(0));
             self.state.push(fresh);
         }
-        if reset_path
-            && let Some(last) = self.state.last_mut()
-        {
+        if reset_path && let Some(last) = self.state.last_mut() {
             last.select(Some(0));
         }
     }
@@ -715,6 +731,48 @@ mod test {
         }
     }
 
+    fn app_with(required: &[&str], repository: Repository) -> super::App {
+        super::App::new(repository, required.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn save_is_gated_on_required_group_picks() {
+        // Mirrors the real `chip` required-group wiring: while no option
+        // from the required group is selected, `can_save` must report
+        // false and `missing_required_groups` must name the group. The
+        // moment a matching option is selected, both flip.
+        let options = vec![
+            chip_group_option(Chip::Esp32),
+            chip_group_option(Chip::Esp32c6),
+            option("alloc", &[]),
+        ];
+        let repository = Repository::new(Chip::Esp32, options, &["alloc".to_string()]);
+        let mut app = app_with(&["chip"], repository);
+
+        assert!(
+            !app.can_save(),
+            "unsatisfied required group must block save"
+        );
+        assert_eq!(app.missing_required_groups(), vec!["chip".to_string()]);
+
+        // Simulate the user ticking `esp32` in the chip group (`toggle_current`
+        // treats the chip radio as non-deselect, so the selection sticks).
+        app.repository.toggle_current(0);
+        assert!(app.can_save(), "required group satisfied — save unlocked");
+        assert!(app.missing_required_groups().is_empty());
+    }
+
+    #[test]
+    fn required_groups_list_is_empty_when_nothing_is_required() {
+        // No `required` entries → Save is never gated, regardless of
+        // selection state. This is the fallback for templates that don't
+        // opt into the mechanism.
+        let repository = Repository::new(Chip::Esp32, vec![option("alloc", &[])], &[]);
+        let app = app_with(&[], repository);
+        assert!(app.can_save());
+        assert!(app.missing_required_groups().is_empty());
+    }
+
     #[test]
     fn toggling_method_clears_other_side_without_restoring_on_toggle_back() {
         // Mirrors the espflash ↔ probe-rs scenario: selecting `method` kicks out all
@@ -771,10 +829,7 @@ mod test {
         let repository = Repository::new(
             Chip::Esp32,
             options,
-            &[
-                "method".to_string(),
-                "dependent".to_string(),
-            ],
+            &["method".to_string(), "dependent".to_string()],
         );
 
         let ui = plain_ui();
@@ -857,11 +912,7 @@ mod test {
             .into_iter()
             .nth(1)
             .unwrap();
-        let text: String = line
-            .spans
-            .iter()
-            .map(|s| s.content.to_string())
-            .collect();
+        let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(
             !actionable,
             "unmet-pos row must report as non-actionable, got: {text:?}"
@@ -978,8 +1029,8 @@ mod test {
         //   * drop selections whose option was removed (remap-by-name),
         //   * cascade out anything whose requirements are now unmet,
         //   * trim `path` to whatever still resolves in the new tree.
-        let initial = vec![
-            GeneratorOptionItem::Category(esp_generate::template::GeneratorOptionCategory {
+        let initial = vec![GeneratorOptionItem::Category(
+            esp_generate::template::GeneratorOptionCategory {
                 name: "cat".to_string(),
                 display_name: "cat".to_string(),
                 help: String::new(),
@@ -989,8 +1040,8 @@ mod test {
                     option("will-vanish", &[]),
                     option("dependent", &["will-vanish"]),
                 ],
-            }),
-        ];
+            },
+        )];
 
         let mut repository = Repository::new(
             Chip::Esp32,
@@ -1008,15 +1059,18 @@ mod test {
         // New tree for a "different chip" — `will-vanish` is gone; the category
         // itself is preserved so the path stays valid. `dependent` has its
         // required option removed so it must cascade out.
-        let rebuilt = vec![
-            GeneratorOptionItem::Category(esp_generate::template::GeneratorOptionCategory {
+        let rebuilt = vec![GeneratorOptionItem::Category(
+            esp_generate::template::GeneratorOptionCategory {
                 name: "cat".to_string(),
                 display_name: "cat".to_string(),
                 help: String::new(),
                 requires: Vec::new(),
-                options: vec![option("survivor", &[]), option("dependent", &["will-vanish"])],
-            }),
-        ];
+                options: vec![
+                    option("survivor", &[]),
+                    option("dependent", &["will-vanish"]),
+                ],
+            },
+        )];
 
         repository.set_options(Chip::Esp32c6, rebuilt);
 
@@ -1077,8 +1131,7 @@ mod test {
             chip_group_option(Chip::Esp32),
             chip_group_option(Chip::Esp32c6),
         ];
-        let mut repository =
-            Repository::new(Chip::Esp32, options, &["esp32".to_string()]);
+        let mut repository = Repository::new(Chip::Esp32, options, &["esp32".to_string()]);
 
         repository.toggle_current(0);
         assert!(
@@ -1243,7 +1296,7 @@ impl App {
 
                 match key.code {
                     Char('q') => self.confirm_quit = true,
-                    Char('s') | Char('S') => {
+                    Char('s') | Char('S') if self.can_save() => {
                         return Ok(AppResult::Save);
                     }
                     Esc => {
@@ -1457,17 +1510,31 @@ impl App {
     }
 
     fn footer_paragraph(&self) -> Paragraph<'_> {
-        let text = if self.confirm_quit {
+        let base = if self.confirm_quit {
             "Are you sure you want to quit? (y/N)"
         } else {
             "Use ↓↑ to move, ESC/← to go up, → to go deeper or change the value, s/S to save and generate, ESC/q to cancel"
         };
 
-        let text = if self.toolchains_loading {
-            format!("{text}  |  Scanning installed toolchains…")
-        } else {
-            text.to_string()
-        };
+        let mut text = base.to_string();
+        if self.toolchains_loading {
+            text.push_str("  |  Scanning installed toolchains…");
+        }
+
+        // Surface the Save gate before anything else: when a required
+        // selection group has no pick yet, `s`/`S` won't do anything, and
+        // the user deserves to know which group is holding them up. The
+        // confirm-quit prompt takes precedence so the user isn't trying
+        // to read two different instructions at once.
+        if !self.confirm_quit {
+            let missing = self.missing_required_groups();
+            if !missing.is_empty() {
+                text.push_str(&format!(
+                    "  |  Cannot save yet — pick one option from: {}",
+                    missing.join(", ")
+                ));
+            }
+        }
 
         Paragraph::new(text)
             .centered()

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -43,11 +43,10 @@ pub struct Repository {
 }
 
 impl Repository {
-    pub fn new(chip: Chip, options: Vec<GeneratorOptionItem>, selected: &[String]) -> Self {
+    pub fn new(options: Vec<GeneratorOptionItem>, selected: &[String]) -> Self {
         let flat_options = flatten_options(&options);
         Self {
             config: ActiveConfiguration {
-                chip,
                 selected: selected
                     .iter()
                     .flat_map(|option| flat_options.iter().position(|o| &o.name == option))
@@ -59,7 +58,7 @@ impl Repository {
         }
     }
 
-    /// Rebuild the options tree for a (possibly different) chip.
+    /// Rebuild the options tree.
     ///
     /// The `options` argument is the *fully prepared* tree: the caller is
     /// responsible for running chip-filtering, module population and toolchain
@@ -70,8 +69,8 @@ impl Repository {
     /// The menu path is trimmed to the depth that still resolves against the
     /// new tree, so categories that vanish drop out while surviving ones keep
     /// the user's cursor in place.
-    pub fn set_options(&mut self, chip: Chip, options: Vec<GeneratorOptionItem>) {
-        self.config.reset_options(chip, options);
+    pub fn set_options(&mut self, options: Vec<GeneratorOptionItem>) {
+        self.config.reset_options(options);
 
         // Trim the navigation path to whatever still resolves in the new tree.
         let mut current: &[GeneratorOptionItem] = &self.config.options;
@@ -101,13 +100,9 @@ impl Repository {
     }
 
     /// Returns the chip that is currently ticked in the `chip` selection
-    /// group, if any. The main loop polls this after every event to detect
-    /// user-driven chip switches; disagreement with [`ActiveConfiguration::chip`]
-    /// triggers a full options-tree rebuild.
-    ///
-    /// Returns `None` only in degenerate situations (e.g. tests that build a
-    /// `Repository` without a chip category). Callers should fall back to
-    /// `self.config.chip` in that case.
+    /// group, if any. Returns `None` only in degenerate situations (e.g. tests
+    /// that build a `Repository` without a chip category, or the user hasn't
+    /// picked a chip yet).
     pub fn selected_chip(&self) -> Option<Chip> {
         self.config.selected.iter().find_map(|idx| {
             let option = &self.config.flat_options[*idx];
@@ -625,8 +620,8 @@ impl App {
     ///
     /// `Repository::set_options` trims the navigation path to whatever still
     /// resolves in the new tree; we mirror that here on the `ListState` stack.
-    pub fn set_options(&mut self, chip: Chip, options: Vec<GeneratorOptionItem>) {
-        self.repository.set_options(chip, options);
+    pub fn set_options(&mut self, options: Vec<GeneratorOptionItem>) {
+        self.repository.set_options(options);
 
         let desired = self.repository.path_len() + 1;
         self.state.truncate(desired.max(1));
@@ -726,7 +721,7 @@ mod test {
             chip_group_option(Chip::Esp32c6),
             option("alloc", &[]),
         ];
-        let repository = Repository::new(Chip::Esp32, options, &["alloc".to_string()]);
+        let repository = Repository::new(options, &["alloc".to_string()]);
         let mut app = app_with(&["chip"], repository);
 
         assert!(
@@ -747,7 +742,7 @@ mod test {
         // No `required` entries → Save is never gated, regardless of
         // selection state. This is the fallback for templates that don't
         // opt into the mechanism.
-        let repository = Repository::new(Chip::Esp32, vec![option("alloc", &[])], &[]);
+        let repository = Repository::new(vec![option("alloc", &[])], &[]);
         let app = app_with(&[], repository);
         assert!(app.can_save());
         assert!(app.missing_required_groups().is_empty());
@@ -767,7 +762,6 @@ mod test {
         ];
 
         let mut repository = Repository::new(
-            Chip::Esp32,
             options,
             &[
                 "method-unselected-a".to_string(),
@@ -807,7 +801,6 @@ mod test {
         ];
 
         let repository = Repository::new(
-            Chip::Esp32,
             options,
             &["method".to_string(), "dependent".to_string()],
         );
@@ -885,7 +878,7 @@ mod test {
             option("method", &[]),
             option("unmet-pos", &["needs-x", "!method"]),
         ];
-        let repository = Repository::new(Chip::Esp32, options, &["method".to_string()]);
+        let repository = Repository::new(options, &["method".to_string()]);
 
         let (actionable, line) = repository
             .current_level_desc(80, &ui, Some(1))
@@ -925,7 +918,6 @@ mod test {
             }),
         ];
         let repository = Repository::new(
-            Chip::Esp32,
             options,
             &["esp32".to_string(), "method".to_string()],
         );
@@ -962,7 +954,6 @@ mod test {
         ];
 
         let repository = Repository::new(
-            Chip::Esp32,
             options,
             &[
                 "loooooong-one".to_string(),
@@ -1024,7 +1015,6 @@ mod test {
         )];
 
         let mut repository = Repository::new(
-            Chip::Esp32,
             initial,
             &[
                 "survivor".to_string(),
@@ -1052,9 +1042,8 @@ mod test {
             },
         )];
 
-        repository.set_options(Chip::Esp32c6, rebuilt);
+        repository.set_options(rebuilt);
 
-        assert_eq!(repository.config.chip, Chip::Esp32c6);
         assert!(repository.config.is_selected("survivor"));
         // Name no longer exists in the new tree: remap-by-name drops it.
         assert!(!repository.config.is_selected("will-vanish"));
@@ -1065,18 +1054,16 @@ mod test {
 
         // Now rebuild with the category itself gone: path must be trimmed.
         let reshaped = vec![option("survivor", &[])];
-        repository.set_options(Chip::Esp32c6, reshaped);
+        repository.set_options(reshaped);
         assert_eq!(repository.path.len(), 0);
         assert!(repository.config.is_selected("survivor"));
     }
 
     #[test]
     fn selected_chip_reports_chip_group_selection() {
-        // `selected_chip` is the bridge the main loop uses to notice user-driven
-        // chip switches. It must return the chip whose group entry is currently
-        // ticked, regardless of what `config.chip` says (divergence is the
-        // whole point — that's how we detect a pending switch), and `None`
-        // when no chip-group option is present in the tree at all.
+        // `selected_chip` returns the chip whose group entry is currently
+        // ticked, and `None` when no chip-group option is present in the tree
+        // at all.
         let options = vec![
             chip_group_option(Chip::Esp32),
             chip_group_option(Chip::Esp32c6),
@@ -1084,20 +1071,13 @@ mod test {
         ];
 
         let repository = Repository::new(
-            Chip::Esp32,
             options,
             &["esp32c6".to_string(), "alloc".to_string()],
         );
 
-        // config.chip still says Esp32 (the tree hasn't been rebuilt yet) but
-        // the user has ticked `esp32c6` in the chip group — the main loop
-        // picks this up and triggers the rebuild.
-        assert_eq!(repository.config.chip, Chip::Esp32);
         assert_eq!(repository.selected_chip(), Some(Chip::Esp32c6));
 
-        // A tree without a chip category means no chip group selection —
-        // falls back to `None`, which the main loop maps to `config.chip`.
-        let no_chip_group = Repository::new(Chip::Esp32, vec![option("alloc", &[])], &[]);
+        let no_chip_group = Repository::new(vec![option("alloc", &[])], &[]);
         assert_eq!(no_chip_group.selected_chip(), None);
     }
 
@@ -1111,7 +1091,7 @@ mod test {
             chip_group_option(Chip::Esp32),
             chip_group_option(Chip::Esp32c6),
         ];
-        let mut repository = Repository::new(Chip::Esp32, options, &["esp32".to_string()]);
+        let mut repository = Repository::new(options, &["esp32".to_string()]);
 
         repository.toggle_current(0);
         assert!(
@@ -1153,7 +1133,6 @@ mod test {
         ];
 
         let repository = Repository::new(
-            Chip::Esp32,
             options,
             &[
                 "esp32".to_string(),
@@ -1221,7 +1200,6 @@ mod test {
         ];
 
         let mut repository = Repository::new(
-            Chip::Esp32,
             initial,
             &[
                 "esp32".to_string(),
@@ -1246,17 +1224,14 @@ mod test {
         repository.toggle_current(1);
         assert_eq!(repository.selected_chip(), Some(Chip::Esp32c6));
 
-        repository.set_options(Chip::Esp32c6, rebuilt);
+        repository.set_options(rebuilt);
 
-        assert_eq!(repository.config.chip, Chip::Esp32c6);
         assert!(repository.config.is_selected("esp32c6"));
         assert!(!repository.config.is_selected("esp32"));
         assert!(repository.config.is_selected("shared"));
         // Chip-filtered out of the tree entirely; rebuild-by-name drops it.
         assert!(!repository.config.is_selected("only-on-esp32"));
-        // And `selected_chip()` now agrees with `config.chip` — no more
-        // pending switch.
-        assert_eq!(repository.selected_chip(), Some(repository.config.chip));
+        assert_eq!(repository.selected_chip(), Some(Chip::Esp32c6));
     }
 }
 

--- a/template/template.yaml
+++ b/template/template.yaml
@@ -1,4 +1,6 @@
 #INCLUDEFILE false
+required:
+  - chip
 options:
   - !Include .template/chip.yaml
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,11 +34,11 @@ const IGNORED_CATEGORIES_FULL: &[&str] = &[
     "module",
 ];
 
-/// Mirror of `esp_generate::main::prune_chip_incompatible_options`'s predicate:
-/// an option is considered chip-compatible when it either has no `compatible:
+/// Minimal chip-compat predicate for the xtask's test-case fanout: an
+/// option is considered chip-compatible when it either has no `compatible:
 /// { chip: [...] }` constraint at all, or its allow-list contains the given
-/// chip. Other `compatible` entries aren't evaluated here — like the binary,
-/// the xtask only applies chip-based filtering at the tree-shaping layer.
+/// chip. Other `compatible` entries aren't evaluated here — the xtask only
+/// needs chip-based filtering to seed its per-chip test matrix.
 fn is_chip_compatible(option: &GeneratorOption, chip: Chip) -> bool {
     match option.compatible.get("chip") {
         None => true,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -210,7 +210,7 @@ fn enable_config_and_dependencies(
     option: &str,
     chip: Chip,
 ) -> Result<()> {
-    let (idx, option) = find_option(option, &config.flat_options, chip)
+    let (idx, option) = find_option(option, &config.flat_options)
         .ok_or_else(|| anyhow::anyhow!("Option not found: {option}"))?;
 
     if config.selected.contains(&idx) {
@@ -351,10 +351,9 @@ fn options_for_chip(chip: Chip, all_combinations: bool) -> Result<Vec<Vec<String
 
     for base_template in &template_selectors {
         for option in &all_options {
-            let (_, option) = find_option(&option, &flat_options, chip)
+            let (_, option) = find_option(&option, &flat_options)
                 .unwrap_or_else(|| panic!("Option not found: {}", option));
             let mut config = ActiveConfiguration {
-                chip,
                 selected: vec![chip_idx],
                 flat_options: flat_options.clone(),
                 options: template.options.clone(),
@@ -409,7 +408,6 @@ fn options_for_chip(chip: Chip, all_combinations: bool) -> Result<Vec<Vec<String
             .cloned()
             .collect();
         let mut config = ActiveConfiguration {
-            chip,
             selected,
             options: template_options.take().unwrap(),
             flat_options: flat_options.take().unwrap(),


### PR DESCRIPTION
Chip is still rather special-cased, but this PR takes steps to resolve that. Hopefully the end result gets rid of this special casing.

The only really iffy part is that chip metadata isn't available without a chip, so some of the template variables will not be available in templates without a chip. `chip` needs to be special-cased to support this distinction, but only this, I believe.