### PR TITLE
Fix Neovim template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed neovim config (#332)
+
 ### Removed
 
 ## [1.3.0-rc.0] - 2026-04-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed neovim config (#332)
+- Fixed neovim config (#336)
 
 ### Removed
 

--- a/template/.nvim.lua
+++ b/template/.nvim.lua
@@ -13,8 +13,12 @@ rust_analyzer.cargo.extraEnv = { RUSTUP_TOOLCHAIN = "esp" }
 rust_analyzer.server = { extraEnv = { RUSTUP_TOOLCHAIN = "stable" } }
 --ENDIF
 
+--IF option("neovim-rustaceanvim")
+vim.lsp.config("rust-analyzer", {
+--ELSE
 -- Note the neovim name of the language server is rust_analyzer with an underscore.
 vim.lsp.config("rust_analyzer", {
+--ENDIF
     settings = {
         ["rust-analyzer"] = rust_analyzer,
     },

--- a/template/.nvim.lua
+++ b/template/.nvim.lua
@@ -9,8 +9,8 @@ local rust_analyzer = {
 }
 --IF option("xtensa")
 --REPLACE esp rust_toolchain
-rust_analyzer.cargo.extraEnv = { RUST_TOOLCHAIN = "esp" }
-rust_analyzer.server = { extraEnv = { RUST_TOOLCHAIN = "stable" } }
+rust_analyzer.cargo.extraEnv = { RUSTUP_TOOLCHAIN = "esp" }
+rust_analyzer.server = { extraEnv = { RUSTUP_TOOLCHAIN = "stable" } }
 --ENDIF
 
 -- Note the neovim name of the language server is rust_analyzer with an underscore.

--- a/template/.nvim.lua
+++ b/template/.nvim.lua
@@ -1,4 +1,4 @@
---INCLUDEFILE option("neovim-rustaceanvim") || option("neovim-classic")
+--INCLUDEFILE option("neovim")
 -- You must enable the exrc setting in neovim for this config file to be used.
 local rust_analyzer = {
     cargo = {
@@ -15,22 +15,14 @@ local rust_analyzer = {
 --IF option("neovim-rustaceanvim")
 -- Note the rustaceanvim name of the language server is rust-analyzer with a dash.
 vim.lsp.config("rust-analyzer", {
-    --IF option("xtensa")
-    cmd = { "rustup", "run", "stable", "rust-analyzer" },
-    --ENDIF
-    settings = {
-        ["rust-analyzer"] = rust_analyzer,
-    },
-})
---ENDIF
---IF option("neovim-classic")
+--ELSE
 -- Note the neovim name of the language server is rust_analyzer with an underscore.
 vim.lsp.config("rust_analyzer", {
-    --IF option("xtensa")
-    cmd = { "rustup", "run", "stable", "rust-analyzer" },
-    --ENDIF
+--ENDIF
+--IF option("xtensa")
+	cmd = { "rustup", "run", "stable", "rust-analyzer" },
+--ENDIF
     settings = {
         ["rust-analyzer"] = rust_analyzer,
     },
 })
---ENDIF

--- a/template/.nvim.lua
+++ b/template/.nvim.lua
@@ -1,4 +1,4 @@
---INCLUDEFILE option("neovim")
+--INCLUDEFILE option("neovim-rustaceanvim") || option("neovim-classic")
 -- You must enable the exrc setting in neovim for this config file to be used.
 local rust_analyzer = {
     cargo = {
@@ -15,14 +15,22 @@ local rust_analyzer = {
 --IF option("neovim-rustaceanvim")
 -- Note the rustaceanvim name of the language server is rust-analyzer with a dash.
 vim.lsp.config("rust-analyzer", {
---ELSE
--- Note the neovim name of the language server is rust_analyzer with an underscore.
-vim.lsp.config("rust_analyzer", {
---ENDIF
---IF option("xtensa")
-	cmd = { "rustup", "run", "stable", "rust-analyzer" },
---ENDIF
+    --IF option("xtensa")
+    cmd = { "rustup", "run", "stable", "rust-analyzer" },
+    --ENDIF
     settings = {
         ["rust-analyzer"] = rust_analyzer,
     },
 })
+--ENDIF
+--IF option("neovim-classic")
+-- Note the neovim name of the language server is rust_analyzer with an underscore.
+vim.lsp.config("rust_analyzer", {
+    --IF option("xtensa")
+    cmd = { "rustup", "run", "stable", "rust-analyzer" },
+    --ENDIF
+    settings = {
+        ["rust-analyzer"] = rust_analyzer,
+    },
+})
+--ENDIF

--- a/template/.nvim.lua
+++ b/template/.nvim.lua
@@ -5,19 +5,22 @@ local rust_analyzer = {
         --REPLACE riscv32imac-unknown-none-elf rust_target
         target = "riscv32imac-unknown-none-elf",
         allTargets = false,
+        --IF option("xtensa")
+        --REPLACE esp rust_toolchain
+        extraEnv = { RUSTUP_TOOLCHAIN = "esp" },
+        --ENDIF
     },
 }
---IF option("xtensa")
---REPLACE esp rust_toolchain
-rust_analyzer.cargo.extraEnv = { RUSTUP_TOOLCHAIN = "esp" }
-rust_analyzer.server = { extraEnv = { RUSTUP_TOOLCHAIN = "stable" } }
---ENDIF
 
 --IF option("neovim-rustaceanvim")
+-- Note the rustaceanvim name of the language server is rust-analyzer with a dash.
 vim.lsp.config("rust-analyzer", {
 --ELSE
 -- Note the neovim name of the language server is rust_analyzer with an underscore.
 vim.lsp.config("rust_analyzer", {
+--ENDIF
+--IF option("xtensa")
+	cmd = { "rustup", "run", "stable", "rust-analyzer" },
 --ENDIF
     settings = {
         ["rust-analyzer"] = rust_analyzer,

--- a/template/template.yaml
+++ b/template/template.yaml
@@ -190,8 +190,14 @@ options:
         display_name: Add settings for Helix Editor
 
       - !Option
-        name: neovim
+        name: neovim-classic
+        selection_group: neovim
         display_name: Add settings for Neovim
+
+      - !Option
+        name: neovim-rustaceanvim
+        selection_group: neovim
+        display_name: Add settings for Neovim (with rustaceanvim)
 
       - !Option
         name: vscode

--- a/template/template.yaml
+++ b/template/template.yaml
@@ -191,12 +191,10 @@ options:
 
       - !Option
         name: neovim-classic
-        selection_group: neovim
         display_name: Add settings for Neovim
 
       - !Option
         name: neovim-rustaceanvim
-        selection_group: neovim
         display_name: Add settings for Neovim (with rustaceanvim)
 
       - !Option

--- a/template/template.yaml
+++ b/template/template.yaml
@@ -191,10 +191,12 @@ options:
 
       - !Option
         name: neovim-classic
+        selection_group: neovim
         display_name: Add settings for Neovim
 
       - !Option
         name: neovim-rustaceanvim
+        selection_group: neovim
         display_name: Add settings for Neovim (with rustaceanvim)
 
       - !Option


### PR DESCRIPTION
**Fix how the stable toolchain is specified in Neovim (Fix #324)**

This PR is a follow-up to #332.
It adds support for both classic Neovim LSP and [rustaceanvim](https://github.com/mrcjkb/rustaceanvim) configurations configurations.