### PR TITLE
Remove special-casing chip, vol. 2

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -61,7 +61,6 @@ enum CheckResult {
 }
 
 pub fn check(
-    project_path: &Path,
     chip: Chip,
     probe_rs_required: bool,
     msrv: Version,
@@ -164,12 +163,6 @@ pub fn check(
             probers_suggestion_kind,
         )
     );
-
-    if offensive_cargo_config_check(project_path) {
-        println!(
-            "⚠️ `.config/cargo.toml` files found in parent directories - this can cause undesired behavior. See https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure"
-        );
-    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -339,7 +332,7 @@ fn try_extract_version(cmd: &str, line: &str) -> Option<Version> {
     })
 }
 
-fn offensive_cargo_config_check(path: &Path) -> bool {
+pub fn offensive_cargo_config_check(path: &Path) -> bool {
     let mut current = if let Some(parent) = path.parent() {
         PathBuf::from(parent)
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,23 +338,6 @@ fn about() -> String {
     about
 }
 
-/// Scan the user's `-o`/`--option` list for an entry that names a [`Chip`]
-/// variant. The chip travels with the rest of the generation options (it's a
-/// normal entry in the `chip` selection group), so `-o esp32c6` both picks
-/// the target and ticks the matching option.
-///
-/// Returns the first match. If the user passes multiple chip options (which
-/// is meaningless since they share a selection group), the conflict is
-/// surfaced later by [`process_options`] via the `same_selection_group` check.
-///
-/// Higher-level *presence* checks (i.e. "did the user pick a chip at all?")
-/// go through [`Template::missing_required_groups`] instead — this helper
-/// exists purely to produce the typed [`Chip`] value the rest of the
-/// generator pipeline consumes.
-fn chip_from_options(options: &[String]) -> Option<Chip> {
-    options.iter().find_map(|opt| opt.parse::<Chip>().ok())
-}
-
 fn setup_args_interactive(args: &mut Args) -> Result<()> {
     if args.headless {
         let mut missing = String::from(
@@ -498,10 +481,6 @@ fn main() -> Result<()> {
         keys
     };
 
-    // `None` until the user picks one in the TUI; headless mode has
-    // already rejected a missing required `chip` selection above.
-    let mut chip: Option<Chip> = chip_from_options(&args.option);
-
     // Initial pruning
     let initial_selections: HashMap<String, String> = TEMPLATE
         .all_options()
@@ -635,8 +614,6 @@ fn main() -> Result<()> {
             return Ok(());
         };
 
-        chip = app.repository.selected_chip();
-
         (sel, app.repository.config.flat_options)
     } else {
         (initial_selected, repository.config.flat_options)
@@ -690,7 +667,13 @@ fn main() -> Result<()> {
         ("esp-hal-version-full", esp_hal_version_full),
     ];
 
-    if let Some(chip) = chip {
+    // Inject chip-specific variables when possible.
+    if let Some(chip) = selected.iter().find(|name| {
+        find_option(name, &flat_options).map_or(false, |(_, opt)| opt.selection_group == "chip")
+    }) {
+        let chip: Chip = chip
+            .parse()
+            .unwrap_or_else(|_| panic!("Not a valid chip name"));
         variables.extend_from_slice(&[
             ("mcu", chip.to_string()),
             ("max-dram2-uninit", chip.dram2_region().size().to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -785,7 +785,7 @@ fn main() -> Result<()> {
 
     if check::offensive_cargo_config_check(&project_dir) {
         println!(
-            "⚠️ `.config/cargo.toml` files found in parent directories - this can cause undesired behavior. See https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure"
+            "⚠️ `.cargo/config.toml` files found in parent directories - this can cause undesired behavior. See https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -690,27 +690,6 @@ fn main() -> Result<()> {
             variables.push(("rust_toolchain", tc.clone()));
         }
 
-        // Merge scalar `sets` entries contributed by the selected options (e.g.
-        // the chip-group option contributes `wokwi-board`). Generator-provided
-        // variables above take precedence — `#REPLACE` lookup is first-match-wins
-        // — so a template author can't accidentally shadow `project-name` /
-        // `mcu` / etc. by declaring them in an option's `sets`.
-        //
-        // List-valued entries (e.g. `remove_pins`) aren't substitutable text and
-        // are consumed directly by the code-generation paths that know what to
-        // do with them (see the pin-reservation block below), so they're
-        // deliberately skipped here instead of being joined into a string.
-        for name in &selected {
-            let Some((_, opt)) = find_option(name, &flat_options) else {
-                continue;
-            };
-            for (key, value) in &opt.sets {
-                if let Some(scalar) = value.as_scalar() {
-                    variables.push((key, scalar.to_string()));
-                }
-            }
-        }
-
         let mut reserved_gpio_code = String::new();
 
         if let Some(remove_pins) = selected.iter().find_map(|name| {
@@ -779,6 +758,27 @@ fn main() -> Result<()> {
             args.headless,
             selected_toolchain.as_deref(),
         );
+    }
+
+    // Merge scalar `sets` entries contributed by the selected options (e.g.
+    // the chip-group option contributes `wokwi-board`). Generator-provided
+    // variables above take precedence — `#REPLACE` lookup is first-match-wins
+    // — so a template author can't accidentally shadow `project-name` /
+    // `mcu` / etc. by declaring them in an option's `sets`.
+    //
+    // List-valued entries (e.g. `remove_pins`) aren't substitutable text and
+    // are consumed directly by the code-generation paths that know what to
+    // do with them (see the pin-reservation block below), so they're
+    // deliberately skipped here instead of being joined into a string.
+    for name in &selected {
+        let Some((_, opt)) = find_option(name, &flat_options) else {
+            continue;
+        };
+        for (key, value) in &opt.sets {
+            if let Some(scalar) = value.as_scalar() {
+                variables.push((key, scalar.to_string()));
+            }
+        }
     }
 
     let project_dir = path.join(&name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -668,23 +668,13 @@ fn main() -> Result<()> {
     // Same lookup for TUI and headless: both branches populated the toolchain
     // category in `flat_options` (TUI via scan results, headless via the
     // `--toolchain` CLI hint), so `find_option` resolves in either case.
-    let selected_toolchain = selected.iter().find_map(|name| {
-        let (_, opt) = find_option(name, &flat_options)?;
-        if opt.selection_group == "toolchain" {
-            Some(name.clone())
-        } else {
-            None
-        }
-    });
-
-    let selected_module = selected.iter().find_map(|name| {
-        let (_, opt) = find_option(name, &flat_options)?;
-        if opt.selection_group == "module" {
-            Some(name.clone())
-        } else {
-            None
-        }
-    });
+    let selected_toolchain = selected
+        .iter()
+        .find(|name| {
+            find_option(name, &flat_options)
+                .map_or(false, |(_, opt)| opt.selection_group == "toolchain")
+        })
+        .cloned();
 
     for idx in 0..selected.len() {
         let (_, option) = find_option(&selected[idx], &flat_options).unwrap();
@@ -737,59 +727,58 @@ fn main() -> Result<()> {
 
     let mut reserved_gpio_code = String::new();
 
-    if let Some(ref module_name) = selected_module {
-        if let Some((_, module_option)) = find_option(module_name, &flat_options) {
-            // The module option carries its limitation tags as a list-valued
-            // `sets` entry; a missing entry means "no pins to reserve", not
-            // an error — e.g. a chip-specific module with nothing special
-            // about its wiring.
-            let remove_pins = module_option
-                .sets
-                .get("remove_pins")
-                .and_then(SetValue::as_list)
-                .unwrap_or(&[]);
-            let restricted_pins = chip.pins().iter().filter(|pin| {
-                remove_pins
-                    .iter()
-                    .any(|lim| pin.limitations.contains(&lim.as_str()))
-            });
-            let strapping_pins = chip
-                .pins()
+    if let Some(remove_pins) = selected.iter().find_map(|name| {
+        // Find module, then get the pins that should be considered for removal/noting.
+        find_option(name, &flat_options)
+            .filter(|(_, opt)| opt.selection_group == "module")
+            .map(|(_, opt)| {
+                opt.sets
+                    .get("remove_pins")
+                    .and_then(SetValue::as_list)
+                    .unwrap_or(&[])
+            })
+    }) {
+        let restricted_pins = chip.pins().iter().filter(|pin| {
+            remove_pins
                 .iter()
-                .filter(|pin| pin.limitations.contains(&"strapping"))
-                .collect::<Vec<_>>();
+                .any(|lim| pin.limitations.contains(&lim.as_str()))
+        });
+        let strapping_pins = chip
+            .pins()
+            .iter()
+            .filter(|pin| pin.limitations.contains(&"strapping"))
+            .collect::<Vec<_>>();
 
-            if !strapping_pins.is_empty() {
-                let strapping = strapping_pins
-                    .iter()
-                    .map(|pin| format!("// - GPIO{}", pin.pin))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                writeln!(
-                    &mut reserved_gpio_code,
-                    r#"// The following pins are used to bootstrap the chip. They are available
+        if !strapping_pins.is_empty() {
+            let strapping = strapping_pins
+                .iter()
+                .map(|pin| format!("// - GPIO{}", pin.pin))
+                .collect::<Vec<_>>()
+                .join("\n");
+            writeln!(
+                &mut reserved_gpio_code,
+                r#"// The following pins are used to bootstrap the chip. They are available
                     // for use, but check the datasheet of the module for more information on them.
                     {strapping}"#
-                )
-                .unwrap();
-            }
-
-            // Only set module-selected if there are GPIOs to reserve
-            if restricted_pins.clone().next().is_some() {
-                selected.push("module-selected".to_string());
-
-                let pin_plucker = restricted_pins
-                    .map(|pin| format!("    let _ = peripherals.GPIO{};", pin.pin))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                writeln!(
-                    &mut reserved_gpio_code,
-                    r#"// These GPIO pins are in use by some feature of the module and should not be used.
-                    {pin_plucker}"#
-                )
-                .unwrap();
-            };
+            )
+            .unwrap();
         }
+
+        // Only set module-selected if there are GPIOs to reserve
+        if restricted_pins.clone().next().is_some() {
+            selected.push("module-selected".to_string());
+
+            let pin_plucker = restricted_pins
+                .map(|pin| format!("    let _ = peripherals.GPIO{};", pin.pin))
+                .collect::<Vec<_>>()
+                .join("\n");
+            writeln!(
+                &mut reserved_gpio_code,
+                r#"// These GPIO pins are in use by some feature of the module and should not be used.
+                {pin_plucker}"#
+            )
+            .unwrap();
+        };
     }
     variables.push(("reserved_gpio_code", reserved_gpio_code));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -648,7 +648,7 @@ fn main() -> Result<()> {
         .iter()
         .find(|name| {
             find_option(name, &flat_options)
-                .map_or(false, |(_, opt)| opt.selection_group == "toolchain")
+                .is_some_and(|(_, opt)| opt.selection_group == "toolchain")
         })
         .cloned();
 
@@ -669,7 +669,7 @@ fn main() -> Result<()> {
 
     // Inject chip-specific variables when possible.
     if let Some(chip) = selected.iter().find(|name| {
-        find_option(name, &flat_options).map_or(false, |(_, opt)| opt.selection_group == "chip")
+        find_option(name, &flat_options).is_some_and(|(_, opt)| opt.selection_group == "chip")
     }) {
         let chip: Chip = chip
             .parse()

--- a/src/main.rs
+++ b/src/main.rs
@@ -697,24 +697,22 @@ fn main() -> Result<()> {
         "riscv".to_string()
     });
 
-    // mark that a toolchain was explicitly selected for template replacements
-    if selected_toolchain.is_some() {
-        selected.push("toolchain-selected".to_string());
-    }
-
-    let max_dram2 = chip.dram2_region().size();
-
     let mut variables = vec![
-        ("project-name".to_string(), name.clone()),
-        ("mcu".to_string(), chip.to_string()),
-        (
-            "generate-version".to_string(),
-            env!("CARGO_PKG_VERSION").to_string(),
-        ),
-        ("generate-parameters".to_string(), selected_options),
-        ("esp-hal-version-full".to_string(), esp_hal_version_full),
-        ("max-dram2-uninit".to_string(), format!("{max_dram2}")),
+        // Generator specific
+        ("generate-version", env!("CARGO_PKG_VERSION").to_string()),
+        // Project specific
+        ("project-name", name.clone()),
+        ("generate-parameters", selected_options),
+        // Template specific
+        ("esp-hal-version-full", esp_hal_version_full),
+        ("mcu", chip.to_string()),
+        ("max-dram2-uninit", chip.dram2_region().size().to_string()),
+        ("rust_target", chip.metadata().target().to_string()),
     ];
+
+    if let Some(tc) = selected_toolchain.as_ref() {
+        variables.push(("rust_toolchain", tc.clone()));
+    }
 
     // Merge scalar `sets` entries contributed by the selected options (e.g.
     // the chip-group option contributes `wokwi-board`). Generator-provided
@@ -732,18 +730,9 @@ fn main() -> Result<()> {
         };
         for (key, value) in &opt.sets {
             if let Some(scalar) = value.as_scalar() {
-                variables.push((key.clone(), scalar.to_string()));
+                variables.push((key, scalar.to_string()));
             }
         }
-    }
-
-    variables.push((
-        "rust_target".to_string(),
-        chip.metadata().target().to_string(),
-    ));
-
-    if let Some(tc) = selected_toolchain.as_ref() {
-        variables.push(("rust_toolchain".to_string(), tc.clone()));
     }
 
     let mut reserved_gpio_code = String::new();
@@ -802,7 +791,7 @@ fn main() -> Result<()> {
             };
         }
     }
-    variables.push(("reserved_gpio_code".to_string(), reserved_gpio_code));
+    variables.push(("reserved_gpio_code", reserved_gpio_code));
 
     let project_dir = path.join(&name);
     fs::create_dir(&project_dir)?;
@@ -955,14 +944,14 @@ impl BlockKind {
 }
 
 fn process_file(
-    contents: &str,                 // Raw content of the file
-    options: &[String],             // Selected options
-    variables: &[(String, String)], // Variables and their values in tuples
-    file_path: &mut String,         // File path to be modified
+    contents: &str,               // Raw content of the file
+    options: &[String],           // Selected options
+    variables: &[(&str, String)], // Variables and their values in tuples
+    file_path: &mut String,       // File path to be modified
 ) -> Option<String> {
     let mut res = String::new();
 
-    let mut replace: Option<Vec<(String, String)>> = None;
+    let mut replace: Option<Vec<(&str, &str)>> = None;
     let mut include = vec![BlockKind::Root];
     let mut file_directives = true;
 
@@ -1026,9 +1015,9 @@ fn process_file(
                 .filter_map(|pair| {
                     let mut parts = pair.split_whitespace();
                     if let (Some(pattern), Some(var_name)) = (parts.next(), parts.next()) {
-                        if let Some((_, value)) = variables.iter().find(|(key, _)| key == var_name)
+                        if let Some((_, value)) = variables.iter().find(|(key, _)| key == &var_name)
                         {
-                            Some((pattern.to_string(), value.clone()))
+                            Some((pattern, value.as_str()))
                         } else {
                             None
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,6 +446,7 @@ fn main() -> Result<()> {
     )
     .expect("Failed to read Cargo.toml");
 
+    // TODO: do not assume esp-hal version is present
     let esp_hal_version = versions.dependency_version("esp-hal");
     let esp_hal_version_full = if let Some(stripped) = esp_hal_version.strip_prefix("~") {
         let mut processed = stripped.to_string();
@@ -641,9 +642,6 @@ fn main() -> Result<()> {
         (initial_selected, repository.config.flat_options)
     };
 
-    // FIXME: do not assume the template even has a "chip" property
-    let chip = chip.expect("chip must be set by the time the TUI exits / headless validates");
-
     let mut toolchain_replaced = false;
 
     let selected_options = selected
@@ -668,6 +666,7 @@ fn main() -> Result<()> {
     // Same lookup for TUI and headless: both branches populated the toolchain
     // category in `flat_options` (TUI via scan results, headless via the
     // `--toolchain` CLI hint), so `find_option` resolves in either case.
+    // Needs to be done before selection groups are appended in the loop below.
     let selected_toolchain = selected
         .iter()
         .find(|name| {
@@ -681,12 +680,6 @@ fn main() -> Result<()> {
         selected.push(option.selection_group.clone());
     }
 
-    selected.push(if chip.metadata().is_xtensa() {
-        "xtensa".to_string()
-    } else {
-        "riscv".to_string()
-    });
-
     let mut variables = vec![
         // Generator specific
         ("generate-version", env!("CARGO_PKG_VERSION").to_string()),
@@ -695,94 +688,124 @@ fn main() -> Result<()> {
         ("generate-parameters", selected_options),
         // Template specific
         ("esp-hal-version-full", esp_hal_version_full),
-        ("mcu", chip.to_string()),
-        ("max-dram2-uninit", chip.dram2_region().size().to_string()),
-        ("rust_target", chip.metadata().target().to_string()),
     ];
 
-    if let Some(tc) = selected_toolchain.as_ref() {
-        variables.push(("rust_toolchain", tc.clone()));
-    }
+    if let Some(chip) = chip {
+        variables.extend_from_slice(&[
+            ("mcu", chip.to_string()),
+            ("max-dram2-uninit", chip.dram2_region().size().to_string()),
+            ("rust_target", chip.metadata().target().to_string()),
+        ]);
 
-    // Merge scalar `sets` entries contributed by the selected options (e.g.
-    // the chip-group option contributes `wokwi-board`). Generator-provided
-    // variables above take precedence — `#REPLACE` lookup is first-match-wins
-    // — so a template author can't accidentally shadow `project-name` /
-    // `mcu` / etc. by declaring them in an option's `sets`.
-    //
-    // List-valued entries (e.g. `remove_pins`) aren't substitutable text and
-    // are consumed directly by the code-generation paths that know what to
-    // do with them (see the pin-reservation block below), so they're
-    // deliberately skipped here instead of being joined into a string.
-    for name in &selected {
-        let Some((_, opt)) = find_option(name, &flat_options) else {
-            continue;
-        };
-        for (key, value) in &opt.sets {
-            if let Some(scalar) = value.as_scalar() {
-                variables.push((key, scalar.to_string()));
+        selected.push(if chip.metadata().is_xtensa() {
+            "xtensa".to_string()
+        } else {
+            "riscv".to_string()
+        });
+
+        if let Some(tc) = selected_toolchain.as_ref() {
+            variables.push(("rust_toolchain", tc.clone()));
+        }
+
+        // Merge scalar `sets` entries contributed by the selected options (e.g.
+        // the chip-group option contributes `wokwi-board`). Generator-provided
+        // variables above take precedence — `#REPLACE` lookup is first-match-wins
+        // — so a template author can't accidentally shadow `project-name` /
+        // `mcu` / etc. by declaring them in an option's `sets`.
+        //
+        // List-valued entries (e.g. `remove_pins`) aren't substitutable text and
+        // are consumed directly by the code-generation paths that know what to
+        // do with them (see the pin-reservation block below), so they're
+        // deliberately skipped here instead of being joined into a string.
+        for name in &selected {
+            let Some((_, opt)) = find_option(name, &flat_options) else {
+                continue;
+            };
+            for (key, value) in &opt.sets {
+                if let Some(scalar) = value.as_scalar() {
+                    variables.push((key, scalar.to_string()));
+                }
             }
         }
-    }
 
-    let mut reserved_gpio_code = String::new();
+        let mut reserved_gpio_code = String::new();
 
-    if let Some(remove_pins) = selected.iter().find_map(|name| {
-        // Find module, then get the pins that should be considered for removal/noting.
-        find_option(name, &flat_options)
-            .filter(|(_, opt)| opt.selection_group == "module")
-            .map(|(_, opt)| {
-                opt.sets
-                    .get("remove_pins")
-                    .and_then(SetValue::as_list)
-                    .unwrap_or(&[])
-            })
-    }) {
-        let restricted_pins = chip.pins().iter().filter(|pin| {
-            remove_pins
+        if let Some(remove_pins) = selected.iter().find_map(|name| {
+            // Find module, then get the pins that should be considered for removal/noting.
+            find_option(name, &flat_options)
+                .filter(|(_, opt)| opt.selection_group == "module")
+                .map(|(_, opt)| {
+                    opt.sets
+                        .get("remove_pins")
+                        .and_then(SetValue::as_list)
+                        .unwrap_or(&[])
+                })
+        }) {
+            let restricted_pins = chip.pins().iter().filter(|pin| {
+                remove_pins
+                    .iter()
+                    .any(|lim| pin.limitations.contains(&lim.as_str()))
+            });
+            let strapping_pins = chip
+                .pins()
                 .iter()
-                .any(|lim| pin.limitations.contains(&lim.as_str()))
-        });
-        let strapping_pins = chip
-            .pins()
-            .iter()
-            .filter(|pin| pin.limitations.contains(&"strapping"))
-            .collect::<Vec<_>>();
+                .filter(|pin| pin.limitations.contains(&"strapping"))
+                .collect::<Vec<_>>();
 
-        if !strapping_pins.is_empty() {
-            let strapping = strapping_pins
-                .iter()
-                .map(|pin| format!("// - GPIO{}", pin.pin))
-                .collect::<Vec<_>>()
-                .join("\n");
-            writeln!(
-                &mut reserved_gpio_code,
-                r#"// The following pins are used to bootstrap the chip. They are available
+            if !strapping_pins.is_empty() {
+                let strapping = strapping_pins
+                    .iter()
+                    .map(|pin| format!("// - GPIO{}", pin.pin))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                writeln!(
+                    &mut reserved_gpio_code,
+                    r#"// The following pins are used to bootstrap the chip. They are available
                     // for use, but check the datasheet of the module for more information on them.
                     {strapping}"#
-            )
-            .unwrap();
-        }
+                )
+                .unwrap();
+            }
 
-        // Only set module-selected if there are GPIOs to reserve
-        if restricted_pins.clone().next().is_some() {
-            selected.push("module-selected".to_string());
+            // Only set module-selected if there are GPIOs to reserve
+            if restricted_pins.clone().next().is_some() {
+                selected.push("module-selected".to_string());
 
-            let pin_plucker = restricted_pins
-                .map(|pin| format!("    let _ = peripherals.GPIO{};", pin.pin))
-                .collect::<Vec<_>>()
-                .join("\n");
-            writeln!(
+                let pin_plucker = restricted_pins
+                    .map(|pin| format!("    let _ = peripherals.GPIO{};", pin.pin))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                writeln!(
                 &mut reserved_gpio_code,
                 r#"// These GPIO pins are in use by some feature of the module and should not be used.
                 {pin_plucker}"#
             )
             .unwrap();
-        };
+            };
+        }
+        variables.push(("reserved_gpio_code", reserved_gpio_code));
+
+        // Check versions and install tools only when a chip is known, and
+        // BEFORE we generate the project.
+        check::check(
+            chip.metadata(),
+            selected.contains(&"probe-rs".to_string()),
+            msrv,
+            selected.contains(&"stack-smashing-protection".to_string())
+                && selected.contains(&"riscv".to_string()),
+            args.headless,
+            selected_toolchain.as_deref(),
+        );
     }
-    variables.push(("reserved_gpio_code", reserved_gpio_code));
 
     let project_dir = path.join(&name);
+
+    if check::offensive_cargo_config_check(&project_dir) {
+        println!(
+            "⚠️ `.config/cargo.toml` files found in parent directories - this can cause undesired behavior. See https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure"
+        );
+    }
+
     fs::create_dir(&project_dir)?;
 
     for &(file_path, contents) in TEMPLATE_FILES.iter() {
@@ -828,17 +851,6 @@ fn main() -> Result<()> {
     } else {
         log::warn!("Current directory is already in a git repository, skipping git initialization");
     }
-
-    check::check(
-        &project_dir,
-        chip.metadata(),
-        selected.contains(&"probe-rs".to_string()),
-        msrv,
-        selected.contains(&"stack-smashing-protection".to_string())
-            && selected.contains(&"riscv".to_string()),
-        args.headless,
-        selected_toolchain.as_deref(),
-    );
 
     Ok(())
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3,7 +3,6 @@ use std::io;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::Chip;
 use env_logger::{Builder, Env, Logger};
 use esp_generate::{
     append_list_as_sentence,
@@ -93,21 +92,6 @@ impl Repository {
             let option = &self.config.flat_options[*idx];
             if option.selection_group == "toolchain" {
                 Some(option.name.clone())
-            } else {
-                None
-            }
-        })
-    }
-
-    /// Returns the chip that is currently ticked in the `chip` selection
-    /// group, if any. Returns `None` only in degenerate situations (e.g. tests
-    /// that build a `Repository` without a chip category, or the user hasn't
-    /// picked a chip yet).
-    pub fn selected_chip(&self) -> Option<Chip> {
-        self.config.selected.iter().find_map(|idx| {
-            let option = &self.config.flat_options[*idx];
-            if option.selection_group == "chip" {
-                option.name.parse().ok()
             } else {
                 None
             }
@@ -1060,28 +1044,6 @@ mod test {
     }
 
     #[test]
-    fn selected_chip_reports_chip_group_selection() {
-        // `selected_chip` returns the chip whose group entry is currently
-        // ticked, and `None` when no chip-group option is present in the tree
-        // at all.
-        let options = vec![
-            chip_group_option(Chip::Esp32),
-            chip_group_option(Chip::Esp32c6),
-            option("alloc", &[]),
-        ];
-
-        let repository = Repository::new(
-            options,
-            &["esp32c6".to_string(), "alloc".to_string()],
-        );
-
-        assert_eq!(repository.selected_chip(), Some(Chip::Esp32c6));
-
-        let no_chip_group = Repository::new(vec![option("alloc", &[])], &[]);
-        assert_eq!(no_chip_group.selected_chip(), None);
-    }
-
-    #[test]
     fn toggle_chip_group_is_a_radio_not_a_toggle() {
         // The chip selection group is a *required* radio: clicking the
         // currently-selected chip must be a no-op (there is no "no chip"
@@ -1219,10 +1181,9 @@ mod test {
         ];
         // Before applying `set_options`, mimic what `toggle_current` would
         // have done: swap the chip-group pick on the *old* tree. This is the
-        // state the main loop sees when it reads `selected_chip()` and
-        // triggers the rebuild.
+        // state the main loop sees when it triggers the rebuild.
         repository.toggle_current(1);
-        assert_eq!(repository.selected_chip(), Some(Chip::Esp32c6));
+        assert!(repository.config.is_selected("esp32c6"));
 
         repository.set_options(rebuilt);
 
@@ -1231,7 +1192,6 @@ mod test {
         assert!(repository.config.is_selected("shared"));
         // Chip-filtered out of the tree entirely; rebuild-by-name drops it.
         assert!(!repository.config.is_selected("only-on-esp32"));
-        assert_eq!(repository.selected_chip(), Some(Chip::Esp32c6));
     }
 }
 


### PR DESCRIPTION
This PR makes it possible to create templates without a `chip` group. This is done by detecting the option group and only injecting some variables when it is present.

Some of this special casing is needed to not duplicate data from E-M-G. The hard-coded pin pluck codegen is necessary because the template language doesn't support a for-each option, but we also don't have the capability to resolve the chip limitation categories into actual chips purely in the template. I think this level of special-casing is acceptable, although a for-each syntax to iterate `sets: key: [list of values]` would help external templates.