### PR TITLE
docs: update supported ESP32 variants list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed neovim config (#336)
+- Fixed the supported ESP32 variants list in the README. (#349)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed neovim config (#336)
-- Fixed the supported ESP32 variants list in the README. (#349)
 
 ### Removed
 
@@ -45,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - esp-generate adds the selected template parameters to the generated code (#293)
 - Add `explain` and `list-options` subcommands (#293)
 - Add module selector (#289)
+- Add C5 and C61 support (#314)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - esp-generate adds the selected template parameters to the generated code (#293)
 - Add `explain` and `list-options` subcommands (#293)
 - Add module selector (#289)
-- Add C5 and C61 support (#314)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Template generation tool to create `no_std` applications targeting Espressif's line of SoCs and modules.
 
-At present, this template supports the ESP32, ESP32-C2/C3/C6, ESP32-H2, and ESP32-S2/S3. Support for additional devices will be added as they become available.
+At present, this template supports the ESP32, ESP32-C2/C3/C5/C6/C61, ESP32-H2, and ESP32-S2/S3. Support for additional devices will be added as they become available.
 
 ## Quickstart
 


### PR DESCRIPTION
Updates the supported ESP32 variants list in the README to match what's available. 