### PR TITLE
fix(template): bound-check linker error-script args before indexing

### DIFF
--- a/template/build.rs
+++ b/template/build.rs
@@ -78,7 +78,10 @@ fn cargo_linker_env_var(target: &str) -> String {
 //ENDIF
 fn linker_be_nice() {
     let args: Vec<String> = std::env::args().collect();
-    if args.len() > 1 {
+    // The helpful-error branch reads both args[1] (kind) and args[2] (what),
+    // so it needs at least 3 args. Guarding on `> 1` left args[2] out of bounds
+    // when the linker wrapper was invoked with exactly 2 arguments.
+    if args.len() > 2 {
         let kind = &args[1];
         let what = &args[2];
 


### PR DESCRIPTION
`linker_be_nice` (in `template/build.rs`) guards its helpful-error branch with `args.len() > 1`, then indexes `args[2]` for the `what` argument. With exactly 2 arguments the guard passes but `args[2]` is out of bounds, so the linker error-handling script panics instead of printing a hint.

Guard on `args.len() > 2` instead, so the branch only runs when both `kind` (`args[1]`) and `what` (`args[2]`) are present. With fewer arguments the script now falls through to emitting the `cargo:rustc-link-arg` lines as before.

Closes #358.