### PR TITLE
prevent use of restricted gpio

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -734,7 +734,7 @@ fn main() -> Result<()> {
                 selected.push("module-selected".to_string());
 
                 let pin_plucker = restricted_pins
-                    .map(|pin| format!("    let _ = peripherals.GPIO{};", pin.pin))
+                    .map(|pin| format!("    let _gpio{} = peripherals.GPIO{};", pin.pin, pin.pin))
                     .collect::<Vec<_>>()
                     .join("\n");
                 writeln!(


### PR DESCRIPTION
i noticed that the `let _ = GPIOX;` form doesn't actually prevent later use the pin. `let _gpiox = GPIOX;` seems to work though.